### PR TITLE
feat(core): Core types and Result monad

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,6 +4,6 @@
   "description": "CLI for validate, capture, test, publish semantic definitions",
   "bin": { "webmcp-bridge": "dist/index.js" },
   "scripts": { "build": "tsc", "test": "vitest run" },
-  "dependencies": { "@webmcp-bridge/core": "workspace:*", "@webmcp-bridge/registry": "workspace:*", "commander": "^12.0.0", "chalk": "^5.3.0" },
+  "dependencies": { "@webmcp-bridge/core": "*", "@webmcp-bridge/registry": "*", "commander": "^12.0.0", "chalk": "^5.3.0" },
   "devDependencies": { "vitest": "^1.2.0", "typescript": "^5.3.0" }
 }

--- a/packages/core/src/types/__tests__/errors.test.ts
+++ b/packages/core/src/types/__tests__/errors.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+
+import { createBridgeError, type BridgeError, type BridgeErrorCode } from '../errors.js';
+
+describe('createBridgeError', () => {
+  it('creates an error with required fields', () => {
+    const error = createBridgeError(
+      'SELECTOR_NOT_FOUND',
+      'Could not find element',
+      'selector',
+    );
+
+    expect(error.code).toBe('SELECTOR_NOT_FOUND');
+    expect(error.message).toBe('Could not find element');
+    expect(error.source).toBe('selector');
+    expect(error.timestamp).toBeInstanceOf(Date);
+  });
+
+  it('generates a timestamp automatically', () => {
+    const before = new Date();
+    const error = createBridgeError('UNKNOWN', 'test', 'engine');
+    const after = new Date();
+
+    expect(error.timestamp.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    expect(error.timestamp.getTime()).toBeLessThanOrEqual(after.getTime());
+  });
+
+  it('merges optional detail fields', () => {
+    const error = createBridgeError(
+      'TOOL_NOT_FOUND',
+      'Tool not found',
+      'engine',
+      {
+        toolName: 'add_todo',
+        pageId: 'todo_list',
+        stepIndex: 3,
+      },
+    );
+
+    expect(error.toolName).toBe('add_todo');
+    expect(error.pageId).toBe('todo_list');
+    expect(error.stepIndex).toBe(3);
+  });
+
+  it('supports fieldId detail', () => {
+    const error = createBridgeError(
+      'SELECTOR_AMBIGUOUS',
+      'Multiple matches',
+      'selector',
+      { fieldId: 'name_input' },
+    );
+    expect(error.fieldId).toBe('name_input');
+  });
+
+  it('supports cause detail', () => {
+    const originalError = new Error('network timeout');
+    const error = createBridgeError(
+      'NAVIGATION_FAILED',
+      'Failed to navigate',
+      'driver',
+      { cause: originalError },
+    );
+    expect(error.cause).toBe(originalError);
+  });
+
+  it('supports screenshot detail', () => {
+    const screenshot = Buffer.from('fake-png-data');
+    const error = createBridgeError(
+      'HEALING_EXHAUSTED',
+      'All healing strategies failed',
+      'healing',
+      { screenshot },
+    );
+    expect(error.screenshot).toBe(screenshot);
+  });
+
+  it('works with all error codes', () => {
+    const codes: BridgeErrorCode[] = [
+      'SELECTOR_NOT_FOUND',
+      'SELECTOR_AMBIGUOUS',
+      'ELEMENT_NOT_INTERACTABLE',
+      'NAVIGATION_FAILED',
+      'NAVIGATION_TIMEOUT',
+      'CAPTURE_FAILED',
+      'CAPTURE_TIMEOUT',
+      'TOOL_NOT_FOUND',
+      'PAGE_NOT_FOUND',
+      'WORKFLOW_STEP_FAILED',
+      'SCHEMA_VALIDATION_ERROR',
+      'YAML_PARSE_ERROR',
+      'HEALING_EXHAUSTED',
+      'FRAME_NOT_FOUND',
+      'DIALOG_UNEXPECTED',
+      'REGISTRY_ERROR',
+      'TIMEOUT',
+      'DRIVER_ERROR',
+      'UNKNOWN',
+    ];
+
+    for (const code of codes) {
+      const error = createBridgeError(code, `Test ${code}`, 'engine');
+      expect(error.code).toBe(code);
+    }
+  });
+
+  it('works with all source types', () => {
+    const sources: BridgeError['source'][] = [
+      'selector',
+      'engine',
+      'capture',
+      'healing',
+      'semantic',
+      'driver',
+      'registry',
+    ];
+
+    for (const source of sources) {
+      const error = createBridgeError('UNKNOWN', `Test ${source}`, source);
+      expect(error.source).toBe(source);
+    }
+  });
+});

--- a/packages/core/src/types/__tests__/result.test.ts
+++ b/packages/core/src/types/__tests__/result.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+
+import { ok, err, isOk, isErr, unwrap, mapResult, type Result } from '../result.js';
+import type { BridgeError } from '../errors.js';
+
+describe('Result monad', () => {
+  describe('ok()', () => {
+    it('creates a success result', () => {
+      const result = ok(42);
+      expect(result).toEqual({ ok: true, value: 42 });
+    });
+
+    it('works with string values', () => {
+      const result = ok('hello');
+      expect(result).toEqual({ ok: true, value: 'hello' });
+    });
+
+    it('works with object values', () => {
+      const obj = { name: 'test', count: 5 };
+      const result = ok(obj);
+      expect(result).toEqual({ ok: true, value: obj });
+    });
+
+    it('works with null and undefined', () => {
+      expect(ok(null)).toEqual({ ok: true, value: null });
+      expect(ok(undefined)).toEqual({ ok: true, value: undefined });
+    });
+  });
+
+  describe('err()', () => {
+    it('creates an error result', () => {
+      const error: BridgeError = {
+        code: 'SELECTOR_NOT_FOUND',
+        message: 'Element not found',
+        source: 'selector',
+        timestamp: new Date(),
+      };
+      const result = err(error);
+      expect(result).toEqual({ ok: false, error });
+    });
+
+    it('works with string errors', () => {
+      const result = err('something went wrong');
+      expect(result).toEqual({ ok: false, error: 'something went wrong' });
+    });
+  });
+
+  describe('isOk()', () => {
+    it('returns true for ok results', () => {
+      expect(isOk(ok(42))).toBe(true);
+    });
+
+    it('returns false for err results', () => {
+      expect(isOk(err('fail'))).toBe(false);
+    });
+
+    it('narrows type correctly', () => {
+      const result: Result<number, string> = ok(42);
+      if (isOk(result)) {
+        // TypeScript should allow accessing .value here
+        expect(result.value).toBe(42);
+      }
+    });
+  });
+
+  describe('isErr()', () => {
+    it('returns true for err results', () => {
+      expect(isErr(err('fail'))).toBe(true);
+    });
+
+    it('returns false for ok results', () => {
+      expect(isErr(ok(42))).toBe(false);
+    });
+
+    it('narrows type correctly', () => {
+      const result: Result<number, string> = err('fail');
+      if (isErr(result)) {
+        // TypeScript should allow accessing .error here
+        expect(result.error).toBe('fail');
+      }
+    });
+  });
+
+  describe('unwrap()', () => {
+    it('returns value for ok results', () => {
+      expect(unwrap(ok(42))).toBe(42);
+    });
+
+    it('throws for err results', () => {
+      const error: BridgeError = {
+        code: 'TOOL_NOT_FOUND',
+        message: 'Tool missing',
+        source: 'engine',
+        timestamp: new Date(),
+      };
+      expect(() => unwrap(err(error))).toThrow('Unwrap called on Err');
+    });
+
+    it('includes error details in thrown message', () => {
+      expect(() => unwrap(err('my error'))).toThrow('my error');
+    });
+  });
+
+  describe('mapResult()', () => {
+    it('transforms value of ok result', () => {
+      const result = mapResult(ok(5), (n) => n * 2);
+      expect(result).toEqual({ ok: true, value: 10 });
+    });
+
+    it('passes through err result unchanged', () => {
+      const original = err('fail');
+      const result = mapResult(original, (n: number) => n * 2);
+      expect(result).toEqual({ ok: false, error: 'fail' });
+    });
+
+    it('supports type-changing transforms', () => {
+      const result = mapResult(ok(42), (n) => String(n));
+      expect(result).toEqual({ ok: true, value: '42' });
+    });
+
+    it('supports chaining', () => {
+      const result = mapResult(
+        mapResult(ok(5), (n) => n + 1),
+        (n) => n * 10,
+      );
+      expect(result).toEqual({ ok: true, value: 60 });
+    });
+  });
+});

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -3,6 +3,6 @@
   "version": "0.1.0",
   "description": "Chrome Extension (Manifest V3) — Capture + Execute modes",
   "scripts": { "build": "vite build", "dev": "vite build --watch", "test": "vitest run" },
-  "dependencies": { "@webmcp-bridge/core": "workspace:*", "react": "^18.2.0", "react-dom": "^18.2.0" },
+  "dependencies": { "@webmcp-bridge/core": "*", "react": "^18.2.0", "react-dom": "^18.2.0" },
   "devDependencies": { "@types/chrome": "^0.0.260", "@types/react": "^18.2.0", "@types/react-dom": "^18.2.0", "@vitejs/plugin-react": "^4.2.0", "vite": "^5.1.0", "vitest": "^1.2.0", "typescript": "^5.3.0" }
 }

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -5,6 +5,6 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": { "build": "tsc", "test": "vitest run" },
-  "dependencies": { "@webmcp-bridge/core": "workspace:*", "playwright": "^1.42.0" },
+  "dependencies": { "@webmcp-bridge/core": "*", "playwright": "^1.42.0" },
   "devDependencies": { "vitest": "^1.2.0", "typescript": "^5.3.0" }
 }

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -5,6 +5,6 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": { "build": "tsc", "test": "vitest run" },
-  "dependencies": { "@webmcp-bridge/core": "workspace:*", "js-yaml": "^4.1.0" },
+  "dependencies": { "@webmcp-bridge/core": "*", "js-yaml": "^4.1.0" },
   "devDependencies": { "vitest": "^1.2.0", "typescript": "^5.3.0" }
 }


### PR DESCRIPTION
## Summary
- Added comprehensive tests for Result monad (`ok`, `err`, `isOk`, `isErr`, `unwrap`, `mapResult`) — 19 tests with 100% coverage
- Added comprehensive tests for `createBridgeError` factory — 8 tests covering all error codes and source types
- Fixed `workspace:*` protocol in sub-package dependencies to use npm-compatible `*`

Closes #1

## Test plan
- [x] All 27 tests pass (`npx vitest run packages/core`)
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (zero warnings)
- [x] All type files compile with strict mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)