### PR TITLE
feat(registry): implement LocalRegistry with file-system storage

### DIFF
--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -1,3 +1,4 @@
 export { LocalRegistry } from './local/local-registry.js';
+export type { RegistryMetadata, RegistryIndex, ListEntry, SearchResult } from './local/local-registry.js';
 export { RemoteRegistry } from './remote/remote-registry.js';
 export type { RegistryEntry, RegistrySearchResult } from './schema/registry-types.js';

--- a/packages/registry/src/local/__tests__/local-registry.test.ts
+++ b/packages/registry/src/local/__tests__/local-registry.test.ts
@@ -1,0 +1,387 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { LocalRegistry } from '../local-registry.js';
+
+/**
+ * Helper: create a valid app directory for install tests.
+ */
+function createTestAppDir(tmpDir: string, appId: string): string {
+  const appDir = path.join(tmpDir, `source-${appId}`);
+  fs.mkdirSync(appDir, { recursive: true });
+  fs.mkdirSync(path.join(appDir, 'pages'), { recursive: true });
+  fs.mkdirSync(path.join(appDir, 'tools'), { recursive: true });
+  fs.mkdirSync(path.join(appDir, 'workflows'), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(appDir, 'app.yaml'),
+    `id: ${appId}
+name: Test App
+base_url: https://example.com
+url_patterns:
+  - /app/**
+description: A test application
+registry:
+  publisher: tester
+  tags:
+    - productivity
+    - web
+  license: MIT
+`,
+  );
+
+  // Create a page
+  fs.writeFileSync(
+    path.join(appDir, 'pages', 'home.yaml'),
+    `id: home
+app: ${appId}
+url_pattern: /app/home
+wait_for: .content
+fields:
+  - id: search_input
+    label: Search
+    type: text
+    selectors:
+      - strategy: css
+        selector: input.search
+    interaction:
+      type: fill
+  - id: search_btn
+    label: Search Button
+    type: action_button
+    selectors:
+      - strategy: css
+        selector: button.search
+    interaction:
+      type: click
+outputs:
+  - id: results
+    label: Results
+    selectors:
+      - strategy: css
+        selector: .results
+`,
+  );
+
+  // Create a tool
+  fs.writeFileSync(
+    path.join(appDir, 'tools', 'search.yaml'),
+    `name: search
+description: Search the app
+inputSchema:
+  type: object
+  properties:
+    query:
+      type: string
+  required: [query]
+bridge:
+  page: home
+  steps:
+    - interact:
+        field: home.fields.search_input
+        value: "{{query}}"
+`,
+  );
+
+  return appDir;
+}
+
+describe('LocalRegistry', () => {
+  let tmpDir: string;
+  let registryBasePath: string;
+  let registry: LocalRegistry;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webmcp-registry-test-'));
+    registryBasePath = path.join(tmpDir, 'registry');
+    registry = new LocalRegistry(registryBasePath);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ─── install ─────────────────────────────────────────────
+
+  describe('install', () => {
+    it('installs app from local directory', async () => {
+      const appDir = createTestAppDir(tmpDir, 'my_app');
+      await registry.install('my_app', '1.0.0', appDir);
+
+      // Verify files were copied
+      const installPath = path.join(registryBasePath, 'my_app', '1.0.0');
+      expect(fs.existsSync(path.join(installPath, 'app.yaml'))).toBe(true);
+      expect(fs.existsSync(path.join(installPath, 'pages', 'home.yaml'))).toBe(true);
+      expect(fs.existsSync(path.join(installPath, 'tools', 'search.yaml'))).toBe(true);
+    });
+
+    it('creates metadata.json on install', async () => {
+      const appDir = createTestAppDir(tmpDir, 'my_app');
+      await registry.install('my_app', '1.0.0', appDir);
+
+      const metadataPath = path.join(registryBasePath, 'my_app', '1.0.0', 'metadata.json');
+      expect(fs.existsSync(metadataPath)).toBe(true);
+
+      const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf-8'));
+      expect(metadata.appId).toBe('my_app');
+      expect(metadata.version).toBe('1.0.0');
+      expect(metadata.name).toBe('Test App');
+      expect(metadata.pageCount).toBe(1);
+      expect(metadata.toolCount).toBe(1);
+    });
+
+    it('updates registry index on install', async () => {
+      const appDir = createTestAppDir(tmpDir, 'my_app');
+      await registry.install('my_app', '1.0.0', appDir);
+
+      const indexPath = path.join(registryBasePath, 'registry-index.json');
+      expect(fs.existsSync(indexPath)).toBe(true);
+
+      const index = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
+      expect(index['my_app']).toBeDefined();
+      expect(index['my_app'].versions).toContain('1.0.0');
+      expect(index['my_app'].latest).toBe('1.0.0');
+    });
+
+    it('rejects install if version already exists', async () => {
+      const appDir = createTestAppDir(tmpDir, 'my_app');
+      await registry.install('my_app', '1.0.0', appDir);
+
+      await expect(registry.install('my_app', '1.0.0', appDir)).rejects.toThrow(
+        /already installed/i,
+      );
+    });
+
+    it('rejects install if app.yaml is missing', async () => {
+      const badDir = path.join(tmpDir, 'bad-app');
+      fs.mkdirSync(badDir, { recursive: true });
+      fs.mkdirSync(path.join(badDir, 'pages'));
+      fs.mkdirSync(path.join(badDir, 'tools'));
+
+      await expect(registry.install('bad_app', '1.0.0', badDir)).rejects.toThrow(
+        /app\.yaml/i,
+      );
+    });
+
+    it('rejects install if pages/ is missing', async () => {
+      const badDir = path.join(tmpDir, 'bad-app');
+      fs.mkdirSync(badDir, { recursive: true });
+      fs.writeFileSync(path.join(badDir, 'app.yaml'), 'id: bad\nname: Bad');
+      fs.mkdirSync(path.join(badDir, 'tools'));
+
+      await expect(registry.install('bad_app', '1.0.0', badDir)).rejects.toThrow(
+        /pages/i,
+      );
+    });
+
+    it('rejects install if tools/ is missing', async () => {
+      const badDir = path.join(tmpDir, 'bad-app');
+      fs.mkdirSync(badDir, { recursive: true });
+      fs.writeFileSync(path.join(badDir, 'app.yaml'), 'id: bad\nname: Bad');
+      fs.mkdirSync(path.join(badDir, 'pages'));
+
+      await expect(registry.install('bad_app', '1.0.0', badDir)).rejects.toThrow(
+        /tools/i,
+      );
+    });
+
+    it('supports multiple versions of same app', async () => {
+      const appDir = createTestAppDir(tmpDir, 'my_app');
+      await registry.install('my_app', '1.0.0', appDir);
+      await registry.install('my_app', '1.1.0', appDir);
+
+      const versions = await registry.listVersions('my_app');
+      expect(versions).toContain('1.0.0');
+      expect(versions).toContain('1.1.0');
+    });
+  });
+
+  // ─── uninstall ───────────────────────────────────────────
+
+  describe('uninstall', () => {
+    it('removes specific version', async () => {
+      const appDir = createTestAppDir(tmpDir, 'my_app');
+      await registry.install('my_app', '1.0.0', appDir);
+
+      await registry.uninstall('my_app', '1.0.0');
+
+      const installPath = path.join(registryBasePath, 'my_app', '1.0.0');
+      expect(fs.existsSync(installPath)).toBe(false);
+    });
+
+    it('updates index after uninstall', async () => {
+      const appDir = createTestAppDir(tmpDir, 'my_app');
+      await registry.install('my_app', '1.0.0', appDir);
+      await registry.install('my_app', '1.1.0', appDir);
+
+      await registry.uninstall('my_app', '1.0.0');
+
+      const indexPath = path.join(registryBasePath, 'registry-index.json');
+      const index = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
+      expect(index['my_app'].versions).not.toContain('1.0.0');
+      expect(index['my_app'].versions).toContain('1.1.0');
+    });
+
+    it('removes app entry from index when last version removed', async () => {
+      const appDir = createTestAppDir(tmpDir, 'my_app');
+      await registry.install('my_app', '1.0.0', appDir);
+      await registry.uninstall('my_app', '1.0.0');
+
+      const indexPath = path.join(registryBasePath, 'registry-index.json');
+      const index = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
+      expect(index['my_app']).toBeUndefined();
+    });
+
+    it('throws when app not found', async () => {
+      await expect(registry.uninstall('nonexistent', '1.0.0')).rejects.toThrow(
+        /not found/i,
+      );
+    });
+  });
+
+  // ─── list ────────────────────────────────────────────────
+
+  describe('list', () => {
+    it('returns empty array when no apps installed', async () => {
+      const result = await registry.list();
+      expect(result).toEqual([]);
+    });
+
+    it('returns all installed apps', async () => {
+      const appDir1 = createTestAppDir(tmpDir, 'app_one');
+      const appDir2 = createTestAppDir(tmpDir, 'app_two');
+      await registry.install('app_one', '1.0.0', appDir1);
+      await registry.install('app_two', '2.0.0', appDir2);
+
+      const result = await registry.list();
+      expect(result).toHaveLength(2);
+
+      const ids = result.map((e) => e.appId);
+      expect(ids).toContain('app_one');
+      expect(ids).toContain('app_two');
+    });
+
+    it('includes version info in list', async () => {
+      const appDir = createTestAppDir(tmpDir, 'my_app');
+      await registry.install('my_app', '1.0.0', appDir);
+      await registry.install('my_app', '1.1.0', appDir);
+
+      const result = await registry.list();
+      expect(result).toHaveLength(1);
+      expect(result[0]!.versions).toContain('1.0.0');
+      expect(result[0]!.versions).toContain('1.1.0');
+    });
+  });
+
+  // ─── listVersions ───────────────────────────────────────
+
+  describe('listVersions', () => {
+    it('returns versions for installed app', async () => {
+      const appDir = createTestAppDir(tmpDir, 'my_app');
+      await registry.install('my_app', '1.0.0', appDir);
+      await registry.install('my_app', '2.0.0', appDir);
+
+      const versions = await registry.listVersions('my_app');
+      expect(versions).toEqual(['1.0.0', '2.0.0']);
+    });
+
+    it('returns empty array for unknown app', async () => {
+      const versions = await registry.listVersions('nonexistent');
+      expect(versions).toEqual([]);
+    });
+  });
+
+  // ─── resolve ─────────────────────────────────────────────
+
+  describe('resolve', () => {
+    it('returns path to latest version by default', async () => {
+      const appDir = createTestAppDir(tmpDir, 'my_app');
+      await registry.install('my_app', '1.0.0', appDir);
+      await registry.install('my_app', '1.1.0', appDir);
+
+      const resolved = await registry.resolve('my_app');
+      expect(resolved).toBe(path.join(registryBasePath, 'my_app', '1.1.0'));
+    });
+
+    it('returns path to specific version', async () => {
+      const appDir = createTestAppDir(tmpDir, 'my_app');
+      await registry.install('my_app', '1.0.0', appDir);
+      await registry.install('my_app', '1.1.0', appDir);
+
+      const resolved = await registry.resolve('my_app', '1.0.0');
+      expect(resolved).toBe(path.join(registryBasePath, 'my_app', '1.0.0'));
+    });
+
+    it('returns null for unknown app', async () => {
+      const resolved = await registry.resolve('nonexistent');
+      expect(resolved).toBeNull();
+    });
+
+    it('returns null for unknown version', async () => {
+      const appDir = createTestAppDir(tmpDir, 'my_app');
+      await registry.install('my_app', '1.0.0', appDir);
+
+      const resolved = await registry.resolve('my_app', '9.9.9');
+      expect(resolved).toBeNull();
+    });
+  });
+
+  // ─── search ──────────────────────────────────────────────
+
+  describe('search', () => {
+    it('returns empty when no apps match', async () => {
+      const appDir = createTestAppDir(tmpDir, 'my_app');
+      await registry.install('my_app', '1.0.0', appDir);
+
+      const results = await registry.search('zzz_nonexistent');
+      expect(results).toEqual([]);
+    });
+
+    it('matches by app name (case-insensitive)', async () => {
+      const appDir = createTestAppDir(tmpDir, 'my_app');
+      await registry.install('my_app', '1.0.0', appDir);
+
+      const results = await registry.search('test app');
+      expect(results).toHaveLength(1);
+      expect(results[0]!.appId).toBe('my_app');
+    });
+
+    it('matches by description (case-insensitive)', async () => {
+      const appDir = createTestAppDir(tmpDir, 'my_app');
+      await registry.install('my_app', '1.0.0', appDir);
+
+      const results = await registry.search('application');
+      expect(results).toHaveLength(1);
+      expect(results[0]!.appId).toBe('my_app');
+    });
+
+    it('matches by app ID', async () => {
+      const appDir = createTestAppDir(tmpDir, 'my_app');
+      await registry.install('my_app', '1.0.0', appDir);
+
+      const results = await registry.search('my_app');
+      expect(results).toHaveLength(1);
+    });
+
+    it('returns all when query is empty', async () => {
+      const appDir1 = createTestAppDir(tmpDir, 'app_one');
+      const appDir2 = createTestAppDir(tmpDir, 'app_two');
+      await registry.install('app_one', '1.0.0', appDir1);
+      await registry.install('app_two', '1.0.0', appDir2);
+
+      const results = await registry.search('');
+      expect(results).toHaveLength(2);
+    });
+
+    it('includes tags in search results', async () => {
+      const appDir = createTestAppDir(tmpDir, 'my_app');
+      await registry.install('my_app', '1.0.0', appDir);
+
+      const results = await registry.search('test');
+      expect(results[0]!.tags).toContain('productivity');
+    });
+  });
+});

--- a/packages/registry/src/local/local-registry.ts
+++ b/packages/registry/src/local/local-registry.ts
@@ -10,37 +10,360 @@
  *         pages/*.yaml
  *         tools/*.yaml
  *         workflows/*.yaml
- *         metadata.json   ← publisher, tags, created_at
+ *         metadata.json   <- publisher, tags, created_at
+ *     registry-index.json
  *
  * Operations:
- * - install(appId, version, sourcePath) → copies from source to registry
- * - uninstall(appId, version) → removes from registry
- * - list() → all installed apps + versions
- * - resolve(appId, version?) → path to semantic directory
- * - search(query) → matching entries by name, tags, description
+ * - install(appId, version, sourcePath) -> copies from source to registry
+ * - uninstall(appId, version) -> removes from registry
+ * - list() -> all installed apps + versions
+ * - listVersions(appId) -> versions for a given app
+ * - resolve(appId, version?) -> path to semantic directory
+ * - search(query) -> matching entries by name, tags, description
  */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+import * as yaml from 'js-yaml';
+
+export interface RegistryMetadata {
+  appId: string;
+  name: string;
+  version: string;
+  description: string;
+  publisher: string;
+  tags: string[];
+  license: string;
+  baseUrl: string;
+  urlPatterns: string[];
+  pageCount: number;
+  toolCount: number;
+  workflowCount: number;
+  installedAt: string;
+  lastUpdated: string;
+}
+
+export interface RegistryIndexEntry {
+  versions: string[];
+  latest: string;
+  metadata: Partial<RegistryMetadata>;
+}
+
+export interface RegistryIndex {
+  [appId: string]: RegistryIndexEntry;
+}
+
+export interface ListEntry {
+  appId: string;
+  versions: string[];
+  latest: string;
+  metadata: Partial<RegistryMetadata>;
+}
+
+export interface SearchResult {
+  appId: string;
+  description: string;
+  tags: string[];
+  name: string;
+  versions: string[];
+  latest: string;
+}
+
 export class LocalRegistry {
-  constructor(private basePath?: string) {
-    // Default: ~/.webmcp-bridge/registry/
+  private readonly basePath: string;
+
+  constructor(basePath?: string) {
+    this.basePath =
+      basePath ?? path.join(os.homedir(), '.webmcp-bridge', 'registry');
   }
 
-  async install(appId: string, version: string, sourcePath: string): Promise<void> {
-    throw new Error('Not implemented — see spec: docs/specs/registry-spec.md');
+  /**
+   * Install an app from a local directory into the registry.
+   */
+  async install(
+    appId: string,
+    version: string,
+    sourcePath: string,
+  ): Promise<void> {
+    // Step 1: Validate source directory structure
+    this.validateAppDirectory(sourcePath);
+
+    // Step 2: Check if already installed
+    const installPath = path.join(this.basePath, appId, version);
+    if (fs.existsSync(installPath)) {
+      throw new Error(
+        `App already installed: ${appId}@${version}`,
+      );
+    }
+
+    // Step 3: Create install directory and copy files
+    fs.mkdirSync(installPath, { recursive: true });
+    this.copyRecursive(sourcePath, installPath);
+
+    // Step 4: Build and save metadata
+    const metadata = this.buildMetadata(sourcePath, appId, version);
+    this.saveMetadata(installPath, metadata);
+
+    // Step 5: Update registry index
+    this.updateIndex(appId, version, metadata);
   }
 
+  /**
+   * Remove an app version from the registry.
+   */
   async uninstall(appId: string, version: string): Promise<void> {
-    throw new Error('Not implemented');
+    const installPath = path.join(this.basePath, appId, version);
+    if (!fs.existsSync(installPath)) {
+      throw new Error(
+        `App not found: ${appId}@${version}`,
+      );
+    }
+
+    // Remove version directory
+    fs.rmSync(installPath, { recursive: true, force: true });
+
+    // Update index
+    const index = this.loadIndex();
+    const entry = index[appId];
+    if (entry) {
+      entry.versions = entry.versions.filter((v) => v !== version);
+      if (entry.versions.length === 0) {
+        delete index[appId];
+        // Remove app directory if empty
+        const appDir = path.join(this.basePath, appId);
+        if (fs.existsSync(appDir)) {
+          const remaining = fs.readdirSync(appDir);
+          if (remaining.length === 0) {
+            fs.rmSync(appDir, { recursive: true, force: true });
+          }
+        }
+      } else {
+        // Update latest to the most recently added remaining version
+        entry.latest = entry.versions[entry.versions.length - 1]!;
+      }
+      this.saveIndex(index);
+    }
   }
 
-  async list(): Promise<Array<{ appId: string; versions: string[] }>> {
-    throw new Error('Not implemented');
+  /**
+   * List all installed apps with their versions.
+   */
+  async list(): Promise<ListEntry[]> {
+    const index = this.loadIndex();
+    const results: ListEntry[] = [];
+
+    for (const [appId, entry] of Object.entries(index)) {
+      results.push({
+        appId,
+        versions: entry.versions,
+        latest: entry.latest,
+        metadata: entry.metadata,
+      });
+    }
+
+    return results;
   }
 
+  /**
+   * List all versions of a specific app.
+   */
+  async listVersions(appId: string): Promise<string[]> {
+    const index = this.loadIndex();
+    const entry = index[appId];
+    return entry ? [...entry.versions] : [];
+  }
+
+  /**
+   * Resolve the filesystem path for an app version.
+   * If no version specified, resolves to latest.
+   * Returns null if not found.
+   */
   async resolve(appId: string, version?: string): Promise<string | null> {
-    throw new Error('Not implemented');
+    const index = this.loadIndex();
+    const entry = index[appId];
+
+    if (!entry) {
+      return null;
+    }
+
+    const targetVersion = version ?? entry.latest;
+    if (!entry.versions.includes(targetVersion)) {
+      return null;
+    }
+
+    const resolvedPath = path.join(this.basePath, appId, targetVersion);
+    if (!fs.existsSync(resolvedPath)) {
+      return null;
+    }
+
+    return resolvedPath;
   }
 
-  async search(query: string): Promise<Array<{ appId: string; description: string; tags: string[] }>> {
-    throw new Error('Not implemented');
+  /**
+   * Search for apps by name, description, or app ID.
+   */
+  async search(
+    query: string,
+  ): Promise<SearchResult[]> {
+    const index = this.loadIndex();
+    const results: SearchResult[] = [];
+    const queryLower = query.toLowerCase();
+
+    for (const [appId, entry] of Object.entries(index)) {
+      const metadata = entry.metadata;
+      const name = (metadata.name ?? '').toLowerCase();
+      const description = (metadata.description ?? '').toLowerCase();
+      const appIdLower = appId.toLowerCase();
+
+      if (
+        queryLower === '' ||
+        name.includes(queryLower) ||
+        description.includes(queryLower) ||
+        appIdLower.includes(queryLower)
+      ) {
+        results.push({
+          appId,
+          name: metadata.name ?? appId,
+          description: metadata.description ?? '',
+          tags: metadata.tags ?? [],
+          versions: entry.versions,
+          latest: entry.latest,
+        });
+      }
+    }
+
+    return results;
+  }
+
+  // ─── Private helpers ──────────────────────────────────────
+
+  private validateAppDirectory(dirPath: string): void {
+    if (!fs.existsSync(path.join(dirPath, 'app.yaml'))) {
+      throw new Error('Missing app.yaml in source directory');
+    }
+    if (!fs.existsSync(path.join(dirPath, 'pages'))) {
+      throw new Error('Missing pages/ directory in source');
+    }
+    if (!fs.existsSync(path.join(dirPath, 'tools'))) {
+      throw new Error('Missing tools/ directory in source');
+    }
+  }
+
+  private copyRecursive(src: string, dest: string): void {
+    const entries = fs.readdirSync(src, { withFileTypes: true });
+    for (const entry of entries) {
+      const srcPath = path.join(src, entry.name);
+      const destPath = path.join(dest, entry.name);
+      if (entry.isDirectory()) {
+        fs.mkdirSync(destPath, { recursive: true });
+        this.copyRecursive(srcPath, destPath);
+      } else if (entry.isFile()) {
+        fs.copyFileSync(srcPath, destPath);
+      }
+    }
+  }
+
+  private buildMetadata(
+    sourcePath: string,
+    appId: string,
+    version: string,
+  ): RegistryMetadata {
+    const appYamlPath = path.join(sourcePath, 'app.yaml');
+    const appYaml = yaml.load(
+      fs.readFileSync(appYamlPath, 'utf-8'),
+    ) as Record<string, unknown>;
+
+    // Handle wrapper key: { app: { ... } } -> { ... }
+    const appData =
+      appYaml && typeof appYaml === 'object' && 'app' in appYaml
+        ? (appYaml['app'] as Record<string, unknown>)
+        : appYaml;
+
+    const pagesDir = path.join(sourcePath, 'pages');
+    const toolsDir = path.join(sourcePath, 'tools');
+    const workflowsDir = path.join(sourcePath, 'workflows');
+
+    const pageCount = this.countYamlFiles(pagesDir);
+    const toolCount = this.countYamlFiles(toolsDir);
+    const workflowCount = fs.existsSync(workflowsDir)
+      ? this.countYamlFiles(workflowsDir)
+      : 0;
+
+    const registryMeta = (appData['registry'] ?? {}) as Record<string, unknown>;
+    const now = new Date().toISOString();
+
+    return {
+      appId,
+      name: (appData['name'] as string) ?? appId,
+      version,
+      description: (appData['description'] as string) ?? '',
+      publisher: (registryMeta['publisher'] as string) ?? '',
+      tags: (registryMeta['tags'] as string[]) ?? [],
+      license: (registryMeta['license'] as string) ?? 'MIT',
+      baseUrl: (appData['base_url'] as string) ?? '',
+      urlPatterns: (appData['url_patterns'] as string[]) ?? [],
+      pageCount,
+      toolCount,
+      workflowCount,
+      installedAt: now,
+      lastUpdated: now,
+    };
+  }
+
+  private countYamlFiles(dirPath: string): number {
+    if (!fs.existsSync(dirPath)) return 0;
+    return fs
+      .readdirSync(dirPath)
+      .filter((f) => /\.(yaml|yml)$/i.test(f)).length;
+  }
+
+  private saveMetadata(
+    installPath: string,
+    metadata: RegistryMetadata,
+  ): void {
+    fs.writeFileSync(
+      path.join(installPath, 'metadata.json'),
+      JSON.stringify(metadata, null, 2),
+      'utf-8',
+    );
+  }
+
+  private loadIndex(): RegistryIndex {
+    const indexPath = path.join(this.basePath, 'registry-index.json');
+    if (!fs.existsSync(indexPath)) {
+      return {};
+    }
+    return JSON.parse(fs.readFileSync(indexPath, 'utf-8')) as RegistryIndex;
+  }
+
+  private saveIndex(index: RegistryIndex): void {
+    fs.mkdirSync(this.basePath, { recursive: true });
+    fs.writeFileSync(
+      path.join(this.basePath, 'registry-index.json'),
+      JSON.stringify(index, null, 2),
+      'utf-8',
+    );
+  }
+
+  private updateIndex(
+    appId: string,
+    version: string,
+    metadata: RegistryMetadata,
+  ): void {
+    const index = this.loadIndex();
+
+    if (!index[appId]) {
+      index[appId] = { versions: [], latest: version, metadata: {} };
+    }
+
+    const entry = index[appId]!;
+    if (!entry.versions.includes(version)) {
+      entry.versions.push(version);
+    }
+    entry.latest = version;
+    entry.metadata = metadata;
+
+    this.saveIndex(index);
   }
 }


### PR DESCRIPTION
## Summary
- Implement `LocalRegistry` in `packages/registry/src/local/local-registry.ts`
- File-system based storage at `~/.webmcp-bridge/registry/`
- Methods: `install()`, `uninstall()`, `list()`, `listVersions()`, `resolve()`, `search()`
- 27 unit tests covering all operations

## Test plan
- [x] Install app from local directory
- [x] Reject duplicate installs
- [x] Reject missing app.yaml / pages/ / tools/
- [x] Multi-version support
- [x] Uninstall with index updates
- [x] List and search
- [x] Resolve paths

Closes #25