### PR TITLE
feat(core): implement ExecutionEngine tool execution

### DIFF
--- a/packages/core/src/engine/__tests__/execution-engine.test.ts
+++ b/packages/core/src/engine/__tests__/execution-engine.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Unit tests for ExecutionEngine.
+ * Uses mock driver and mock semantic store.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ExecutionEngine } from '../execution-engine.js';
+import { createMockDriver } from '../../drivers/mock-driver.js';
+import type { BridgeDriver } from '../../types/bridge-driver.js';
+import type { SemanticStore } from '../../semantic/semantic-store.js';
+import type { SelectorResolver } from '../../selector/selector-resolver.js';
+import type { ResultCapturer } from '../../capture/result-capturer.js';
+import type { HealingPipeline } from '../../healing/healing-pipeline.js';
+import type { ToolDefinition, PageDefinition, FieldDefinition, OutputDefinition, AppDefinition } from '../../types/semantic-model.js';
+import { ok, err } from '../../types/result.js';
+import { createBridgeError } from '../../types/errors.js';
+
+// ─── Fixtures ────────────────────────────────────────
+
+const mockField: FieldDefinition = {
+  id: 'name_input',
+  label: 'Name',
+  type: 'text',
+  selectors: [{ strategy: 'css', selector: '#name' }],
+  interaction: { type: 'text_input' },
+};
+
+const mockButtonField: FieldDefinition = {
+  id: 'submit_btn',
+  label: 'Submit',
+  type: 'action_button',
+  selectors: [{ strategy: 'css', selector: '#submit' }],
+  interaction: { type: 'click' },
+};
+
+const mockOutput: OutputDefinition = {
+  id: 'result_text',
+  label: 'Result',
+  selectors: [{ strategy: 'css', selector: '.result' }],
+};
+
+const mockPage: PageDefinition = {
+  id: 'test_page',
+  app: 'test-app',
+  url_pattern: '/',
+  url_template: '{{app.base_url}}/',
+  wait_for: '.loaded',
+  fields: [mockField, mockButtonField],
+  outputs: [mockOutput],
+};
+
+const mockApp: AppDefinition = {
+  id: 'test-app',
+  name: 'Test App',
+  base_url: 'http://localhost:3000',
+  url_patterns: ['http://localhost:3000/**'],
+};
+
+const mockTool: ToolDefinition = {
+  name: 'create_item',
+  description: 'Create an item',
+  inputSchema: {
+    type: 'object',
+    properties: { name: { type: 'string', description: 'Item name' } },
+    required: ['name'],
+  },
+  bridge: {
+    page: 'test_page',
+    steps: [
+      { navigate: { page: 'test_page' } },
+      { interact: { field: 'test_page.fields.name_input', action: 'fill', value: '{{name}}' } },
+      { interact: { action: 'click', target: 'test_page.fields.submit_btn' } },
+      { capture: { from: 'test_page.outputs.result_text', store_as: 'result', wait: true } },
+    ],
+    returns: { result: '{{result}}' },
+  },
+};
+
+// ─── Mock Factories ─────────────────────────────────
+
+function createMockStore(overrides?: Partial<SemanticStore>): SemanticStore {
+  return {
+    getTool: vi.fn().mockReturnValue(mockTool),
+    getPage: vi.fn().mockReturnValue(mockPage),
+    getApp: vi.fn().mockReturnValue(mockApp),
+    getWorkflow: vi.fn().mockReturnValue(undefined),
+    resolveFieldRef: vi.fn().mockImplementation((ref: string) => {
+      if (ref === 'test_page.fields.name_input') return mockField;
+      if (ref === 'test_page.fields.submit_btn') return mockButtonField;
+      return undefined;
+    }),
+    resolveOutputRef: vi.fn().mockImplementation((ref: string) => {
+      if (ref === 'test_page.outputs.result_text') return mockOutput;
+      return undefined;
+    }),
+    listTools: vi.fn().mockReturnValue([mockTool]),
+    ...overrides,
+  } as unknown as SemanticStore;
+}
+
+function createMockResolver(overrides?: Partial<SelectorResolver>): SelectorResolver {
+  return {
+    resolve: vi.fn().mockResolvedValue(ok({
+      element: { _brand: 'ElementHandle' as const },
+      strategyIndex: 0,
+      strategyName: 'css',
+    })),
+    resolveText: vi.fn().mockResolvedValue(ok('mock text')),
+    resolvePattern: vi.fn().mockResolvedValue(ok(null)),
+    ...overrides,
+  } as unknown as SelectorResolver;
+}
+
+function createMockCapturer(overrides?: Partial<ResultCapturer>): ResultCapturer {
+  return {
+    capture: vi.fn().mockResolvedValue(ok('captured value')),
+    captureAll: vi.fn().mockResolvedValue(ok({})),
+    ...overrides,
+  } as unknown as ResultCapturer;
+}
+
+function createMockHealer(overrides?: Partial<HealingPipeline>): HealingPipeline {
+  return {
+    heal: vi.fn().mockResolvedValue(err(createBridgeError('HEALING_EXHAUSTED', 'All healing failed', 'healing'))),
+    ...overrides,
+  } as unknown as HealingPipeline;
+}
+
+// ─── Tests ──────────────────────────────────────────
+
+describe('ExecutionEngine', () => {
+  let engine: ExecutionEngine;
+  let store: SemanticStore;
+  let resolver: SelectorResolver;
+  let capturer: ResultCapturer;
+  let healer: HealingPipeline;
+  let driver: BridgeDriver;
+
+  beforeEach(() => {
+    store = createMockStore();
+    resolver = createMockResolver();
+    capturer = createMockCapturer();
+    healer = createMockHealer();
+    driver = createMockDriver();
+    engine = new ExecutionEngine(store, resolver, capturer, healer);
+  });
+
+  describe('executeTool', () => {
+    it('should return TOOL_NOT_FOUND for unknown tool', async () => {
+      (store.getTool as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+      const result = await engine.executeTool('unknown', {}, driver);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('TOOL_NOT_FOUND');
+      }
+    });
+
+    it('should return PAGE_NOT_FOUND when tool references missing page', async () => {
+      (store.getPage as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+      const result = await engine.executeTool('create_item', { name: 'Test' }, driver);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('PAGE_NOT_FOUND');
+      }
+    });
+
+    it('should execute a simple tool successfully', async () => {
+      const result = await engine.executeTool('create_item', { name: 'Test Item' }, driver);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.success).toBe(true);
+        expect(result.value.stepsExecuted).toBe(4);
+        expect(result.value.outputs).toHaveProperty('result');
+      }
+    });
+
+    it('should navigate to page URL', async () => {
+      await engine.executeTool('create_item', { name: 'Test' }, driver);
+      expect(driver.goto).toHaveBeenCalledWith('http://localhost:3000/');
+    });
+
+    it('should wait for page ready selector', async () => {
+      await engine.executeTool('create_item', { name: 'Test' }, driver);
+      expect(driver.waitFor).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'selector', value: '.loaded' }),
+      );
+    });
+
+    it('should type rendered value into field', async () => {
+      await engine.executeTool('create_item', { name: 'Hello World' }, driver);
+      expect(driver.type).toHaveBeenCalledWith(
+        expect.objectContaining({ _brand: 'ElementHandle' }),
+        'Hello World',
+      );
+    });
+
+    it('should click the button', async () => {
+      await engine.executeTool('create_item', { name: 'Test' }, driver);
+      expect(driver.click).toHaveBeenCalled();
+    });
+
+    it('should capture output values', async () => {
+      (capturer.capture as ReturnType<typeof vi.fn>).mockResolvedValue(ok('3 items left'));
+      const result = await engine.executeTool('create_item', { name: 'Test' }, driver);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.outputs.result).toBe('3 items left');
+      }
+    });
+
+    it('should handle navigation failure', async () => {
+      (driver.goto as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('net::ERR_FAILED'));
+      const result = await engine.executeTool('create_item', { name: 'Test' }, driver);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('NAVIGATION_FAILED');
+      }
+    });
+
+    it('should handle selector failure with healing attempt', async () => {
+      (resolver.resolve as ReturnType<typeof vi.fn>).mockResolvedValue(
+        err(createBridgeError('SELECTOR_NOT_FOUND', 'not found', 'selector')),
+      );
+      const result = await engine.executeTool('create_item', { name: 'Test' }, driver);
+      expect(result.ok).toBe(false);
+      // Healing was attempted but failed (default mock)
+      expect(healer.heal).toHaveBeenCalled();
+    });
+
+    it('should succeed when healing finds element', async () => {
+      // First call to resolve fails, then succeeds (for the button step)
+      (resolver.resolve as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(err(createBridgeError('SELECTOR_NOT_FOUND', 'not found', 'selector')))
+        .mockResolvedValue(ok({ element: { _brand: 'ElementHandle' as const }, strategyIndex: 0, strategyName: 'css' }));
+
+      (healer.heal as ReturnType<typeof vi.fn>).mockResolvedValue(ok({
+        element: { _brand: 'ElementHandle' as const },
+        newSelector: { strategy: 'css', selector: '#name-healed' },
+        stage: 'fuzzy_match',
+      }));
+
+      const result = await engine.executeTool('create_item', { name: 'Test' }, driver);
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe('executeTool with conditional steps', () => {
+    it('should skip step when condition is false', async () => {
+      const conditionalTool: ToolDefinition = {
+        ...mockTool,
+        name: 'conditional_tool',
+        bridge: {
+          page: 'test_page',
+          steps: [
+            { navigate: { page: 'test_page' } },
+            { interact: { field: 'test_page.fields.name_input', action: 'fill', value: 'test' }, condition: '{{skip_fill}}' } as unknown as typeof mockTool.bridge.steps[0],
+          ],
+        },
+      };
+
+      (store.getTool as ReturnType<typeof vi.fn>).mockReturnValue(conditionalTool);
+      const result = await engine.executeTool('conditional_tool', { skip_fill: false }, driver);
+      expect(result.ok).toBe(true);
+      // type should NOT have been called since condition was falsy
+      expect(driver.type).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('executeTool with evaluate_js step', () => {
+    it('should evaluate JavaScript', async () => {
+      const jsTool: ToolDefinition = {
+        ...mockTool,
+        name: 'js_tool',
+        bridge: {
+          page: 'test_page',
+          steps: [
+            { navigate: { page: 'test_page' } },
+            { evaluate_js: 'document.title' },
+          ],
+        },
+      };
+
+      (store.getTool as ReturnType<typeof vi.fn>).mockReturnValue(jsTool);
+      const result = await engine.executeTool('js_tool', {}, driver);
+      expect(result.ok).toBe(true);
+      expect(driver.evaluate).toHaveBeenCalledWith('document.title');
+    });
+  });
+
+  describe('executeTool with wait step', () => {
+    it('should wait for specified duration', async () => {
+      const waitTool: ToolDefinition = {
+        ...mockTool,
+        name: 'wait_tool',
+        bridge: {
+          page: 'test_page',
+          steps: [
+            { navigate: { page: 'test_page' } },
+            { wait: 1000 },
+          ],
+        },
+      };
+
+      (store.getTool as ReturnType<typeof vi.fn>).mockReturnValue(waitTool);
+      const result = await engine.executeTool('wait_tool', {}, driver);
+      expect(result.ok).toBe(true);
+      // waitFor called for navigate + explicit wait
+      expect(driver.waitFor).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'timeout', value: 1000 }),
+      );
+    });
+  });
+
+  describe('getToolSchemas', () => {
+    it('should return all tool schemas', () => {
+      const schemas = engine.getToolSchemas();
+      expect(schemas).toHaveLength(1);
+      expect(schemas[0]!.name).toBe('create_item');
+      expect(schemas[0]!.description).toBe('Create an item');
+      expect(schemas[0]!.inputSchema).toBeDefined();
+    });
+  });
+
+  describe('executeWorkflow', () => {
+    it('should return error for unknown workflow', async () => {
+      const result = await engine.executeWorkflow('unknown', {}, driver);
+      expect(result.ok).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/engine/execution-engine.ts
+++ b/packages/core/src/engine/execution-engine.ts
@@ -5,30 +5,32 @@
  * 1. Loads a ToolDefinition or WorkflowDefinition from SemanticStore
  * 2. Iterates through steps sequentially
  * 3. For each step, delegates to appropriate handler:
- *    - navigate → driver.goto() with URL template rendering
- *    - interact → SelectorResolver + driver interaction methods
- *    - capture → ResultCapturer
- *    - wait → driver.waitFor() or setTimeout
- *    - tab → driver.getNamedPage() / createPage()
- *    - evaluate_js → driver.evaluate()
+ *    - navigate -> driver.goto() with URL template rendering
+ *    - interact -> SelectorResolver + driver interaction methods
+ *    - capture -> ResultCapturer
+ *    - wait -> driver.waitFor() or setTimeout
+ *    - tab -> driver.getNamedPage() / createPage()
+ *    - evaluate_js -> driver.evaluate()
  * 4. Manages variable context (captured values available as {{var}})
  * 5. On selector failure, invokes HealingPipeline
  * 6. For workflows: handles for_each loops, on_error, aggregation
- *
- * Implementation notes for agents:
- * - Use TemplateRenderer for {{variable}} substitution in step params
- * - Maintain a context Map<string, unknown> that accumulates captured values
- * - condition fields on steps: evaluate as truthy/falsy (skip step if falsy)
- * - Returns a ToolExecutionResult with all captured outputs
  */
-import type { BridgeDriver } from '../types/bridge-driver.js';
-import type { ToolDefinition, WorkflowDefinition } from '../types/semantic-model.js';
+import type { BridgeDriver, ElementHandle } from '../types/bridge-driver.js';
+import type {
+  ToolStep,
+  WorkflowStep,
+  PageDefinition,
+  FieldDefinition,
+} from '../types/semantic-model.js';
 import type { Result } from '../types/result.js';
 import type { BridgeError } from '../types/errors.js';
+import { ok, err } from '../types/result.js';
+import { createBridgeError } from '../types/errors.js';
 import type { SemanticStore } from '../semantic/semantic-store.js';
 import type { SelectorResolver } from '../selector/selector-resolver.js';
 import type { ResultCapturer } from '../capture/result-capturer.js';
 import type { HealingPipeline } from '../healing/healing-pipeline.js';
+import { TemplateRenderer } from '../utils/template-renderer.js';
 
 export interface ToolExecutionResult {
   /** All captured output values */
@@ -50,13 +52,26 @@ export interface WorkflowExecutionResult {
   durationMs: number;
 }
 
+interface ExecutionContext {
+  toolName?: string;
+  workflowName?: string;
+  variables: Map<string, unknown>;
+  currentPage?: PageDefinition;
+  stepIndex: number;
+  startTime: number;
+}
+
 export class ExecutionEngine {
+  private templateRenderer: TemplateRenderer;
+
   constructor(
     private store: SemanticStore,
     private selectorResolver: SelectorResolver,
     private resultCapturer: ResultCapturer,
     private healingPipeline: HealingPipeline,
-  ) {}
+  ) {
+    this.templateRenderer = new TemplateRenderer();
+  }
 
   /**
    * Execute a tool by name with given inputs.
@@ -66,8 +81,87 @@ export class ExecutionEngine {
     inputs: Record<string, unknown>,
     driver: BridgeDriver,
   ): Promise<Result<ToolExecutionResult, BridgeError>> {
-    // TODO: Implement — see spec: docs/specs/execution-engine-spec.md
-    throw new Error('Not implemented');
+    const startTime = Date.now();
+
+    // Step 1: Load tool definition
+    const tool = this.store.getTool(toolName);
+    if (!tool) {
+      return err(createBridgeError(
+        'TOOL_NOT_FOUND',
+        `Tool not found: ${toolName}`,
+        'engine',
+        { toolName },
+      ));
+    }
+
+    // Step 2: Load initial page
+    const page = this.store.getPage(tool.bridge.page);
+    if (!page) {
+      return err(createBridgeError(
+        'PAGE_NOT_FOUND',
+        `Page not found: ${tool.bridge.page}`,
+        'engine',
+        { toolName },
+      ));
+    }
+
+    // Step 3: Initialize context
+    const context: ExecutionContext = {
+      toolName,
+      variables: new Map(Object.entries(inputs)),
+      currentPage: page,
+      stepIndex: 0,
+      startTime,
+    };
+
+    // Step 4: Execute each step
+    const outputs: Record<string, unknown> = {};
+    let stepsExecuted = 0;
+
+    for (const step of tool.bridge.steps) {
+      const stepResult = await this.executeToolStep(step, context, driver);
+
+      stepsExecuted++;
+      context.stepIndex++;
+
+      if (!stepResult.ok) {
+        return err(createBridgeError(
+          stepResult.error.code,
+          `Step ${context.stepIndex} failed: ${stepResult.error.message}`,
+          'engine',
+          { toolName, stepIndex: context.stepIndex, cause: stepResult.error },
+        ));
+      }
+
+      // Store captured value
+      if (stepResult.value.capturedValue !== undefined) {
+        const captureKey = stepResult.value.captureKey ?? `step_${stepsExecuted}`;
+        outputs[captureKey] = stepResult.value.capturedValue;
+      }
+    }
+
+    // Step 5: Apply returns mapping
+    let finalOutputs: Record<string, unknown>;
+    if (tool.bridge.returns) {
+      finalOutputs = {};
+      for (const [key, valueTemplate] of Object.entries(tool.bridge.returns)) {
+        finalOutputs[key] = this.templateRenderer.render(
+          valueTemplate,
+          context.variables,
+        );
+      }
+    } else {
+      finalOutputs = outputs;
+    }
+
+    const durationMs = Date.now() - startTime;
+
+    return ok({
+      success: true,
+      outputs: finalOutputs,
+      stepsExecuted,
+      durationMs,
+    });
   }
 
   /**
@@ -78,15 +172,489 @@ export class ExecutionEngine {
     inputs: Record<string, unknown>,
     driver: BridgeDriver,
   ): Promise<Result<WorkflowExecutionResult, BridgeError>> {
-    // TODO: Implement
-    throw new Error('Not implemented');
+    const startTime = Date.now();
+
+    const workflow = this.store.getWorkflow(workflowName);
+    if (!workflow) {
+      return err(createBridgeError(
+        'TOOL_NOT_FOUND',
+        `Workflow not found: ${workflowName}`,
+        'engine',
+      ));
+    }
+
+    const context: ExecutionContext = {
+      workflowName,
+      variables: new Map(Object.entries(inputs)),
+      stepIndex: 0,
+      startTime,
+    };
+
+    let stepsExecuted = 0;
+    const errors: BridgeError[] = [];
+
+    for (const step of workflow.steps) {
+      const stepResult = await this.executeWorkflowStep(step, context, driver);
+
+      stepsExecuted++;
+      context.stepIndex++;
+
+      if (!stepResult.ok) {
+        return err(createBridgeError(
+          stepResult.error.code,
+          `Workflow step ${context.stepIndex} failed: ${stepResult.error.message}`,
+          'engine',
+          { stepIndex: context.stepIndex, cause: stepResult.error },
+        ));
+      }
+    }
+
+    const durationMs = Date.now() - startTime;
+    const outputs: Record<string, unknown> = {};
+    for (const [k, v] of context.variables) {
+      outputs[k] = v;
+    }
+
+    return ok({
+      success: true,
+      outputs,
+      errors,
+      durationMs,
+    });
   }
 
   /**
    * Get all tool schemas (for exposing to LLM as function definitions).
    */
   getToolSchemas(): Array<{ name: string; description: string; inputSchema: unknown; outputSchema?: unknown }> {
-    // TODO: Implement — iterate all tools, return schema objects
-    throw new Error('Not implemented');
+    const tools = this.store.listTools();
+    return tools.map(t => ({
+      name: t.name,
+      description: t.description,
+      inputSchema: t.inputSchema,
+      outputSchema: t.outputSchema,
+    }));
   }
+
+  // ─── Private: Tool Step Dispatch ───────────────────
+
+  private async executeToolStep(
+    step: ToolStep,
+    context: ExecutionContext,
+    driver: BridgeDriver,
+  ): Promise<Result<{ capturedValue?: unknown; captureKey?: string }, BridgeError>> {
+    const stepObj = step as unknown as Record<string, unknown>;
+
+    // Check condition
+    if ('condition' in stepObj && typeof stepObj['condition'] === 'string') {
+      const condResult = this.templateRenderer.evaluateCondition(
+        stepObj['condition'],
+        context.variables,
+      );
+      if (!condResult) {
+        return ok({});
+      }
+    }
+
+    if ('navigate' in stepObj) {
+      return this.executeNavigateStep(
+        stepObj['navigate'] as { page: string; params?: Record<string, string> },
+        context,
+        driver,
+      );
+    }
+    if ('interact' in stepObj) {
+      return this.executeInteractStep(
+        stepObj['interact'] as { field?: string; action?: string; value?: string; target?: string },
+        context,
+        driver,
+      );
+    }
+    if ('capture' in stepObj) {
+      return this.executeCaptureStep(
+        stepObj['capture'] as { from: string; store_as: string; wait?: boolean },
+        context,
+        driver,
+      );
+    }
+    if ('wait' in stepObj) {
+      return this.executeWaitStep(stepObj['wait'] as number | string, driver);
+    }
+    if ('tab' in stepObj) {
+      return this.executeTabStep(stepObj['tab'] as string, driver);
+    }
+    if ('auth' in stepObj) {
+      return ok({});
+    }
+    if ('evaluate_js' in stepObj) {
+      return this.executeEvaluateStep(stepObj['evaluate_js'] as string, context, driver);
+    }
+
+    return err(createBridgeError('DRIVER_ERROR', 'Unknown step type', 'engine'));
+  }
+
+  private async executeNavigateStep(
+    navigate: { page: string; params?: Record<string, string> },
+    context: ExecutionContext,
+    driver: BridgeDriver,
+  ): Promise<Result<{ capturedValue?: unknown; captureKey?: string }, BridgeError>> {
+    const page = this.store.getPage(navigate.page);
+    if (!page) {
+      return err(createBridgeError('PAGE_NOT_FOUND', `Page not found: ${navigate.page}`, 'engine'));
+    }
+
+    context.currentPage = page;
+
+    const urlTemplate = page.url_template ?? page.url_pattern;
+    const renderVars = new Map(context.variables);
+    if (navigate.params) {
+      for (const [k, v] of Object.entries(navigate.params)) {
+        renderVars.set(k, v);
+      }
+    }
+
+    const app = this.store.getApp(page.app);
+    if (app) {
+      renderVars.set('app', { base_url: app.base_url });
+    }
+
+    const renderedUrl = this.templateRenderer.render(urlTemplate, renderVars);
+
+    try {
+      await driver.goto(renderedUrl);
+    } catch (e: unknown) {
+      return err(createBridgeError(
+        'NAVIGATION_FAILED',
+        `Failed to navigate to ${renderedUrl}: ${e instanceof Error ? e.message : String(e)}`,
+        'engine',
+      ));
+    }
+
+    try {
+      await driver.waitFor({ type: 'selector', value: page.wait_for, timeout: 30000 });
+    } catch {
+      return err(createBridgeError(
+        'NAVIGATION_TIMEOUT',
+        `Timeout waiting for page ready: ${page.wait_for}`,
+        'engine',
+      ));
+    }
+
+    return ok({});
+  }
+
+  private async executeInteractStep(
+    interact: { field?: string; action?: string; value?: string; target?: string },
+    context: ExecutionContext,
+    driver: BridgeDriver,
+  ): Promise<Result<{ capturedValue?: unknown; captureKey?: string }, BridgeError>> {
+    const fieldRef = interact.field ?? interact.target;
+
+    if (!fieldRef) {
+      return err(createBridgeError(
+        'SELECTOR_NOT_FOUND',
+        'No field or target specified in interact step',
+        'engine',
+      ));
+    }
+
+    const renderedValue = interact.value
+      ? this.templateRenderer.render(interact.value, context.variables)
+      : undefined;
+
+    const field: FieldDefinition | undefined = this.store.resolveFieldRef(fieldRef);
+    if (!field) {
+      return err(createBridgeError(
+        'SELECTOR_NOT_FOUND',
+        `Field not found: ${fieldRef}`,
+        'engine',
+        { fieldId: fieldRef },
+      ));
+    }
+
+    const resolveResult = await this.selectorResolver.resolve(field.selectors, driver);
+
+    let element: ElementHandle;
+    if (!resolveResult.ok) {
+      const healResult = await this.healingPipeline.heal(
+        field.selectors,
+        field.label,
+        driver,
+      );
+      if (!healResult.ok) {
+        return err(createBridgeError(
+          'SELECTOR_NOT_FOUND',
+          `Could not find field ${fieldRef} and healing failed`,
+          'engine',
+          { fieldId: fieldRef, stepIndex: context.stepIndex },
+        ));
+      }
+      element = healResult.value.element;
+    } else {
+      element = resolveResult.value.element;
+    }
+
+    const action = interact.action ?? field.interaction.type;
+
+    try {
+      switch (action) {
+        case 'click':
+          await driver.click(element);
+          break;
+        case 'fill':
+        case 'type':
+        case 'text_input':
+          if (renderedValue !== undefined) {
+            await driver.type(element, renderedValue);
+          }
+          break;
+        case 'select':
+          if (renderedValue !== undefined) {
+            await driver.select(element, renderedValue);
+          }
+          break;
+        case 'check':
+          await driver.check(element, true);
+          break;
+        case 'uncheck':
+          await driver.check(element, false);
+          break;
+        case 'clear':
+          await driver.clear(element);
+          break;
+        case 'hover':
+          await driver.hover(element);
+          break;
+        default:
+          if (field.type === 'action_button') {
+            await driver.click(element);
+          }
+          break;
+      }
+    } catch (e: unknown) {
+      return err(createBridgeError(
+        'DRIVER_ERROR',
+        `Action "${action}" failed on field ${fieldRef}: ${e instanceof Error ? e.message : String(e)}`,
+        'engine',
+        { fieldId: fieldRef, stepIndex: context.stepIndex },
+      ));
+    }
+
+    return ok({});
+  }
+
+  private async executeCaptureStep(
+    capture: { from: string; store_as: string; wait?: boolean },
+    context: ExecutionContext,
+    driver: BridgeDriver,
+  ): Promise<Result<{ capturedValue?: unknown; captureKey?: string }, BridgeError>> {
+    const output = this.store.resolveOutputRef(capture.from);
+    if (!output) {
+      return err(createBridgeError(
+        'CAPTURE_FAILED',
+        `Output not found: ${capture.from}`,
+        'engine',
+      ));
+    }
+
+    if (capture.wait) {
+      try {
+        await driver.waitFor({ type: 'timeout', value: 500 });
+      } catch {
+        // Ignore wait errors
+      }
+    }
+
+    const captureResult = await this.resultCapturer.capture(output, driver);
+    if (!captureResult.ok) {
+      return err(createBridgeError(
+        captureResult.error.code,
+        `Failed to capture output ${capture.from}: ${captureResult.error.message}`,
+        'engine',
+      ));
+    }
+
+    context.variables.set(capture.store_as, captureResult.value);
+
+    return ok({
+      capturedValue: captureResult.value,
+      captureKey: capture.store_as,
+    });
+  }
+
+  private async executeWaitStep(
+    wait: number | string,
+    driver: BridgeDriver,
+  ): Promise<Result<{ capturedValue?: unknown; captureKey?: string }, BridgeError>> {
+    const durationMs = typeof wait === 'number' ? wait : parseDuration(wait);
+    try {
+      await driver.waitFor({ type: 'timeout', value: durationMs });
+    } catch {
+      // Ignore
+    }
+    return ok({});
+  }
+
+  private async executeTabStep(
+    tab: string,
+    driver: BridgeDriver,
+  ): Promise<Result<{ capturedValue?: unknown; captureKey?: string }, BridgeError>> {
+    try {
+      await driver.getNamedPage(tab);
+    } catch {
+      try {
+        await driver.createPage(tab);
+      } catch {
+        return err(createBridgeError(
+          'DRIVER_ERROR',
+          `Failed to get or create tab: ${tab}`,
+          'engine',
+        ));
+      }
+    }
+    return ok({});
+  }
+
+  private async executeEvaluateStep(
+    js: string,
+    context: ExecutionContext,
+    driver: BridgeDriver,
+  ): Promise<Result<{ capturedValue?: unknown; captureKey?: string }, BridgeError>> {
+    const renderedJs = this.templateRenderer.render(js, context.variables);
+    try {
+      await driver.evaluate(renderedJs);
+    } catch (e: unknown) {
+      return err(createBridgeError(
+        'DRIVER_ERROR',
+        `JS evaluation failed: ${e instanceof Error ? e.message : String(e)}`,
+        'engine',
+      ));
+    }
+    return ok({});
+  }
+
+  // ─── Workflow Step Dispatch ────────────────────────
+
+  private async executeWorkflowStep(
+    step: WorkflowStep,
+    context: ExecutionContext,
+    driver: BridgeDriver,
+  ): Promise<Result<{ capturedValue?: unknown }, BridgeError>> {
+    const stepObj = step as unknown as Record<string, unknown>;
+
+    if ('tool' in stepObj) {
+      return this.executeWorkflowToolStep(
+        stepObj as unknown as { tool: string; params: Record<string, string>; capture?: Record<string, string>; on_error?: string },
+        context,
+        driver,
+      );
+    }
+
+    if ('for_each' in stepObj) {
+      return this.executeWorkflowForEachStep(
+        stepObj as unknown as { for_each: string; as: string; steps: WorkflowStep[]; on_error?: string },
+        context,
+        driver,
+      );
+    }
+
+    if ('aggregate' in stepObj) {
+      return this.executeWorkflowAggregateStep(
+        stepObj as unknown as { aggregate: Record<string, string> },
+        context,
+      );
+    }
+
+    if ('auth' in stepObj) {
+      return ok({});
+    }
+
+    return err(createBridgeError('DRIVER_ERROR', 'Unknown workflow step type', 'engine'));
+  }
+
+  private async executeWorkflowToolStep(
+    toolStep: { tool: string; params: Record<string, string>; capture?: Record<string, string>; on_error?: string },
+    context: ExecutionContext,
+    driver: BridgeDriver,
+  ): Promise<Result<{ capturedValue?: unknown }, BridgeError>> {
+    const renderedParams: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(toolStep.params)) {
+      renderedParams[k] = this.templateRenderer.render(v, context.variables);
+    }
+
+    const toolResult = await this.executeTool(toolStep.tool, renderedParams, driver);
+
+    if (!toolResult.ok) {
+      if (toolStep.on_error === 'skip') {
+        return ok({});
+      }
+      return err(toolResult.error);
+    }
+
+    if (toolStep.capture) {
+      for (const [varName, outputKey] of Object.entries(toolStep.capture)) {
+        const value = toolResult.value.outputs[outputKey];
+        context.variables.set(varName, value);
+      }
+    }
+
+    return ok({});
+  }
+
+  private async executeWorkflowForEachStep(
+    forEachStep: { for_each: string; as: string; steps: WorkflowStep[]; on_error?: string },
+    context: ExecutionContext,
+    driver: BridgeDriver,
+  ): Promise<Result<{ capturedValue?: unknown }, BridgeError>> {
+    const iterable = context.variables.get(forEachStep.for_each);
+
+    if (!Array.isArray(iterable)) {
+      return err(createBridgeError(
+        'WORKFLOW_STEP_FAILED',
+        `for_each variable is not an array: ${forEachStep.for_each}`,
+        'engine',
+      ));
+    }
+
+    for (const item of iterable) {
+      context.variables.set(forEachStep.as, item);
+
+      for (const innerStep of forEachStep.steps) {
+        const innerResult = await this.executeWorkflowStep(innerStep, context, driver);
+
+        if (!innerResult.ok) {
+          if (forEachStep.on_error === 'continue') {
+            break;
+          }
+          return err(innerResult.error);
+        }
+      }
+    }
+
+    return ok({});
+  }
+
+  private executeWorkflowAggregateStep(
+    aggregate: { aggregate: Record<string, string> },
+    context: ExecutionContext,
+  ): Result<{ capturedValue?: unknown }, BridgeError> {
+    for (const [key, template] of Object.entries(aggregate.aggregate)) {
+      const value = this.templateRenderer.render(template, context.variables);
+      context.variables.set(key, value);
+    }
+    return ok({});
+  }
+}
+
+function parseDuration(duration: string): number {
+  const msMatch = duration.match(/^(\d+)\s*ms$/);
+  if (msMatch?.[1]) {
+    return parseInt(msMatch[1], 10);
+  }
+  const sMatch = duration.match(/^(\d+)\s*s$/);
+  if (sMatch?.[1]) {
+    return parseInt(sMatch[1], 10) * 1000;
+  }
+  const num = parseInt(duration, 10);
+  return isNaN(num) ? 5000 : num;
 }


### PR DESCRIPTION
## Summary
- Implements full ExecutionEngine with tool step execution: navigate, interact, capture, wait, tab, evaluate_js
- Workflow execution with for_each loops, aggregate steps, tool chaining
- Template rendering for {{variable}} substitution across all step params
- Healing pipeline integration on selector failure
- getToolSchemas() for LLM function calling
- Added listTools() to SemanticStore

## Test plan
- [x] 16 unit tests passing
- [x] TypeScript typecheck passes
- [x] Tests cover: tool not found, page not found, successful execution, navigation failure, healing, conditional steps, evaluate_js, wait, getToolSchemas

Closes #10

Generated with [Claude Code](https://claude.com/claude-code)