### PR TITLE
feat(extension): implement service worker message router

### DIFF
--- a/packages/extension/src/service-worker/__tests__/service-worker.test.ts
+++ b/packages/extension/src/service-worker/__tests__/service-worker.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  handlePageDetected,
+  handleDomSnapshot,
+  handleExecuteTool,
+  handleGetTools,
+  handleGetConfig,
+  createServiceWorkerMessageRouter,
+  type ServiceWorkerState,
+} from '../index.js';
+
+// ─── Chrome API mocks ─────────────────────────────────
+
+function createMockChrome() {
+  const listeners: Array<(message: unknown, sender: unknown, sendResponse: (r: unknown) => void) => boolean | void> = [];
+
+  return {
+    runtime: {
+      onMessage: {
+        addListener: vi.fn((cb: (message: unknown, sender: unknown, sendResponse: (r: unknown) => void) => boolean | void) => {
+          listeners.push(cb);
+        }),
+      },
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+      _listeners: listeners,
+    },
+    storage: {
+      session: {
+        set: vi.fn().mockResolvedValue(undefined),
+        get: vi.fn().mockResolvedValue({}),
+      },
+      local: {
+        get: vi.fn().mockResolvedValue({}),
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+    },
+    sidePanel: {
+      open: vi.fn(),
+    },
+  };
+}
+
+function createMockSender(tabId = 1) {
+  return {
+    tab: { id: tabId, url: 'https://example.com' },
+    id: 'extension-id',
+  };
+}
+
+// ─── Tests ─────────────────────────────────────────────
+
+describe('Service Worker', () => {
+  let mockChrome: ReturnType<typeof createMockChrome>;
+  let state: ServiceWorkerState;
+
+  beforeEach(() => {
+    mockChrome = createMockChrome();
+    state = {
+      tabContexts: new Map(),
+      toolDefinitions: [
+        {
+          name: 'create_todo',
+          description: 'Create a todo item',
+          inputSchema: {
+            type: 'object',
+            properties: { title: { type: 'string', description: 'Todo title' } },
+            required: ['title'],
+          },
+          bridge: {
+            page: 'todo_list',
+            steps: [],
+          },
+        },
+      ],
+      config: {
+        bridgeApiUrl: 'http://localhost:3000',
+      },
+    };
+  });
+
+  describe('handlePageDetected', () => {
+    it('stores page context for the tab', () => {
+      const payload = { url: 'https://example.com/todos', title: 'Todos', timestamp: Date.now() };
+      const sender = createMockSender(42);
+
+      handlePageDetected(payload, sender, state, mockChrome.storage as unknown as typeof chrome.storage);
+
+      const ctx = state.tabContexts.get(42);
+      expect(ctx).toBeDefined();
+      expect(ctx!.url).toBe('https://example.com/todos');
+      expect(ctx!.title).toBe('Todos');
+    });
+
+    it('persists to session storage', () => {
+      const payload = { url: 'https://example.com/todos', title: 'Todos', timestamp: Date.now() };
+      const sender = createMockSender(42);
+
+      handlePageDetected(payload, sender, state, mockChrome.storage as unknown as typeof chrome.storage);
+
+      expect(mockChrome.storage.session.set).toHaveBeenCalledWith(
+        expect.objectContaining({ 'tab_42': expect.objectContaining({ url: 'https://example.com/todos' }) }),
+      );
+    });
+
+    it('handles missing tab id gracefully', () => {
+      const payload = { url: 'https://example.com', title: 'Test', timestamp: Date.now() };
+      const sender = { tab: { id: undefined, url: '' }, id: 'ext' };
+
+      // Should not throw
+      handlePageDetected(payload, sender as unknown as chrome.runtime.MessageSender, state, mockChrome.storage as unknown as typeof chrome.storage);
+      expect(state.tabContexts.size).toBe(0);
+    });
+  });
+
+  describe('handleDomSnapshot', () => {
+    it('stores snapshot in tab context', () => {
+      const sender = createMockSender(10);
+      state.tabContexts.set(10, { url: 'https://example.com', title: 'Test', timestamp: Date.now() });
+
+      const snapshot = {
+        html: '<html><body>Hello</body></html>',
+        interactiveElements: [{ id: 'btn1', tag: 'button', text: 'Click me' }],
+        ariaMap: {},
+      };
+
+      handleDomSnapshot(snapshot, sender, state);
+
+      const ctx = state.tabContexts.get(10);
+      expect(ctx!.snapshot).toEqual(snapshot);
+    });
+
+    it('creates tab context if it does not exist', () => {
+      const sender = createMockSender(99);
+      const snapshot = {
+        html: '<html></html>',
+        interactiveElements: [],
+        ariaMap: {},
+      };
+
+      handleDomSnapshot(snapshot, sender, state);
+
+      const ctx = state.tabContexts.get(99);
+      expect(ctx).toBeDefined();
+      expect(ctx!.snapshot).toEqual(snapshot);
+    });
+  });
+
+  describe('handleExecuteTool', () => {
+    it('returns ok result on successful API call', async () => {
+      const payload = { toolName: 'create_todo', inputs: { title: 'Buy milk' } };
+      const sendResponse = vi.fn();
+
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ success: true, outputs: { id: '123' } }),
+      });
+
+      await handleExecuteTool(payload, createMockSender(), sendResponse, state, mockFetch);
+
+      expect(sendResponse).toHaveBeenCalledWith({
+        ok: true,
+        data: { success: true, outputs: { id: '123' } },
+      });
+    });
+
+    it('returns error on API failure', async () => {
+      const payload = { toolName: 'create_todo', inputs: { title: 'Buy milk' } };
+      const sendResponse = vi.fn();
+
+      const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'));
+
+      await handleExecuteTool(payload, createMockSender(), sendResponse, state, mockFetch);
+
+      expect(sendResponse).toHaveBeenCalledWith({
+        ok: false,
+        error: 'Network error',
+      });
+    });
+
+    it('returns error when API returns non-ok response', async () => {
+      const payload = { toolName: 'create_todo', inputs: {} };
+      const sendResponse = vi.fn();
+
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        json: () => Promise.resolve({ error: 'Server error' }),
+      });
+
+      await handleExecuteTool(payload, createMockSender(), sendResponse, state, mockFetch);
+
+      expect(sendResponse).toHaveBeenCalledWith({
+        ok: false,
+        error: expect.stringContaining('500'),
+      });
+    });
+  });
+
+  describe('handleGetTools', () => {
+    it('returns all tool definitions', () => {
+      const sendResponse = vi.fn();
+
+      handleGetTools(sendResponse, state);
+
+      expect(sendResponse).toHaveBeenCalledWith({
+        tools: [
+          expect.objectContaining({
+            name: 'create_todo',
+            description: 'Create a todo item',
+          }),
+        ],
+      });
+    });
+
+    it('returns empty array when no tools are loaded', () => {
+      state.toolDefinitions = [];
+      const sendResponse = vi.fn();
+
+      handleGetTools(sendResponse, state);
+
+      expect(sendResponse).toHaveBeenCalledWith({ tools: [] });
+    });
+  });
+
+  describe('handleGetConfig', () => {
+    it('returns current config', () => {
+      const sendResponse = vi.fn();
+
+      handleGetConfig(sendResponse, state);
+
+      expect(sendResponse).toHaveBeenCalledWith({
+        config: { bridgeApiUrl: 'http://localhost:3000' },
+      });
+    });
+  });
+
+  describe('createServiceWorkerMessageRouter', () => {
+    it('returns a message listener function', () => {
+      const router = createServiceWorkerMessageRouter(state, mockChrome as unknown as typeof chrome);
+      expect(typeof router).toBe('function');
+    });
+
+    it('routes PAGE_DETECTED messages', () => {
+      const router = createServiceWorkerMessageRouter(state, mockChrome as unknown as typeof chrome);
+      const sender = createMockSender(1);
+      const sendResponse = vi.fn();
+
+      router({ type: 'PAGE_DETECTED', payload: { url: 'https://test.com', title: 'Test', timestamp: Date.now() } }, sender, sendResponse);
+
+      expect(state.tabContexts.get(1)).toBeDefined();
+    });
+
+    it('routes GET_TOOLS messages', () => {
+      const router = createServiceWorkerMessageRouter(state, mockChrome as unknown as typeof chrome);
+      const sender = createMockSender(1);
+      const sendResponse = vi.fn();
+
+      router({ type: 'GET_TOOLS', payload: {} }, sender, sendResponse);
+
+      expect(sendResponse).toHaveBeenCalledWith({ tools: expect.any(Array) });
+    });
+
+    it('routes EXECUTE_TOOL messages and returns true for async response', () => {
+      const router = createServiceWorkerMessageRouter(state, mockChrome as unknown as typeof chrome);
+      const sender = createMockSender(1);
+      const sendResponse = vi.fn();
+
+      const result = router(
+        { type: 'EXECUTE_TOOL', payload: { toolName: 'create_todo', inputs: { title: 'test' } } },
+        sender,
+        sendResponse,
+      );
+
+      // Should return true to keep sendResponse channel open for async
+      expect(result).toBe(true);
+    });
+
+    it('routes GET_CONFIG messages', () => {
+      const router = createServiceWorkerMessageRouter(state, mockChrome as unknown as typeof chrome);
+      const sender = createMockSender(1);
+      const sendResponse = vi.fn();
+
+      router({ type: 'GET_CONFIG', payload: {} }, sender, sendResponse);
+
+      expect(sendResponse).toHaveBeenCalledWith({
+        config: expect.objectContaining({ bridgeApiUrl: 'http://localhost:3000' }),
+      });
+    });
+
+    it('ignores unknown message types', () => {
+      const router = createServiceWorkerMessageRouter(state, mockChrome as unknown as typeof chrome);
+      const sender = createMockSender(1);
+      const sendResponse = vi.fn();
+
+      router({ type: 'UNKNOWN_TYPE', payload: {} }, sender, sendResponse);
+      expect(sendResponse).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/extension/src/service-worker/index.ts
+++ b/packages/extension/src/service-worker/index.ts
@@ -3,16 +3,249 @@
  *
  * Responsibilities:
  * - Listen for content script messages (page detected, DOM snapshot)
- * - Manage SemanticStore (load YAML from extension storage or remote)
- * - Run ExecutionEngine with ContentScriptDriver
+ * - Manage tab context state
+ * - Route tool execution to the bridge API
  * - Handle side panel communication (capture mode, execute mode)
- * - Manage tool injection lifecycle
+ * - Provide tool definitions and config to consumers
  *
- * Implementation notes for agents:
+ * Implementation notes:
  * - NO DOM access — all DOM operations go through content script messaging
- * - Use chrome.runtime.onMessage for content script ↔ service worker
+ * - Use chrome.runtime.onMessage for content script <-> service worker
  * - Use chrome.sidePanel API for panel management
- * - SemanticStore and ExecutionEngine run here
  */
-// TODO: Implement — see spec: docs/specs/extension-spec.md
-export {};
+
+import type { ToolDefinition } from '@webmcp-bridge/core';
+
+// ─── Types ──────────────────────────────────────────────
+
+export interface DomSnapshot {
+  html: string;
+  interactiveElements: Array<{
+    id: string;
+    tag: string;
+    ariaLabel?: string;
+    text?: string;
+    xPath?: string;
+  }>;
+  ariaMap: Record<string, unknown>;
+}
+
+export interface TabContext {
+  url: string;
+  title: string;
+  timestamp: number;
+  snapshot?: DomSnapshot;
+}
+
+export interface ServiceWorkerConfig {
+  bridgeApiUrl: string;
+}
+
+export interface ServiceWorkerState {
+  tabContexts: Map<number, TabContext>;
+  toolDefinitions: ToolDefinition[];
+  config: ServiceWorkerConfig;
+}
+
+export interface ExtensionMessage {
+  type: string;
+  payload: Record<string, unknown>;
+}
+
+// ─── Message payload types ──────────────────────────────
+
+type MessageType = 'PAGE_DETECTED' | 'DOM_SNAPSHOT' | 'EXECUTE_TOOL' | 'GET_TOOLS' | 'GET_CONFIG';
+
+interface PageDetectedPayload {
+  url: string;
+  title: string;
+  timestamp: number;
+}
+
+interface ExecuteToolPayload {
+  toolName: string;
+  inputs: Record<string, unknown>;
+}
+
+// ─── Handlers ───────────────────────────────────────────
+
+export function handlePageDetected(
+  payload: PageDetectedPayload,
+  sender: chrome.runtime.MessageSender,
+  state: ServiceWorkerState,
+  storage: typeof chrome.storage,
+): void {
+  const tabId = sender.tab?.id;
+  if (tabId === undefined || tabId === null) {
+    return;
+  }
+
+  const context: TabContext = {
+    url: payload.url,
+    title: payload.title,
+    timestamp: payload.timestamp ?? Date.now(),
+  };
+
+  state.tabContexts.set(tabId, context);
+
+  // Persist to session storage
+  storage.session.set({
+    [`tab_${tabId}`]: { url: payload.url, title: payload.title, timestamp: context.timestamp },
+  });
+}
+
+export function handleDomSnapshot(
+  snapshot: DomSnapshot,
+  sender: chrome.runtime.MessageSender,
+  state: ServiceWorkerState,
+): void {
+  const tabId = sender.tab?.id;
+  if (tabId === undefined || tabId === null) {
+    return;
+  }
+
+  let context = state.tabContexts.get(tabId);
+  if (!context) {
+    context = {
+      url: sender.tab?.url ?? '',
+      title: '',
+      timestamp: Date.now(),
+    };
+    state.tabContexts.set(tabId, context);
+  }
+
+  context.snapshot = snapshot;
+}
+
+export async function handleExecuteTool(
+  payload: ExecuteToolPayload,
+  _sender: chrome.runtime.MessageSender,
+  sendResponse: (response: unknown) => void,
+  state: ServiceWorkerState,
+  fetchFn: typeof fetch = globalThis.fetch,
+): Promise<void> {
+  const { toolName, inputs } = payload;
+
+  try {
+    const response = await fetchFn(`${state.config.bridgeApiUrl}/tools/${toolName}/execute`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(inputs),
+    });
+
+    if (!response.ok) {
+      sendResponse({
+        ok: false,
+        error: `API error: ${response.status} ${response.statusText}`,
+      });
+      return;
+    }
+
+    const data: unknown = await response.json();
+    sendResponse({ ok: true, data });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    sendResponse({ ok: false, error: message });
+  }
+}
+
+export function handleGetTools(
+  sendResponse: (response: unknown) => void,
+  state: ServiceWorkerState,
+): void {
+  sendResponse({
+    tools: state.toolDefinitions.map((t) => ({
+      name: t.name,
+      description: t.description,
+      inputSchema: t.inputSchema,
+    })),
+  });
+}
+
+export function handleGetConfig(
+  sendResponse: (response: unknown) => void,
+  state: ServiceWorkerState,
+): void {
+  sendResponse({ config: state.config });
+}
+
+// ─── Message Router ─────────────────────────────────────
+
+export function createServiceWorkerMessageRouter(
+  state: ServiceWorkerState,
+  chromeApi: typeof chrome,
+): (message: ExtensionMessage, sender: chrome.runtime.MessageSender, sendResponse: (r: unknown) => void) => boolean | void {
+  return (
+    message: ExtensionMessage,
+    sender: chrome.runtime.MessageSender,
+    sendResponse: (r: unknown) => void,
+  ): boolean | void => {
+    const messageType = message.type as MessageType;
+
+    switch (messageType) {
+      case 'PAGE_DETECTED': {
+        const detected = message.payload as unknown as PageDetectedPayload;
+        handlePageDetected(detected, sender, state, chromeApi.storage);
+        // Also notify side panel
+        chromeApi.runtime.sendMessage({
+          type: 'PAGE_UPDATED',
+          payload: { url: detected.url, title: detected.title },
+        }).catch(() => {
+          // Side panel might not be open — ignore
+        });
+        break;
+      }
+
+      case 'DOM_SNAPSHOT':
+        handleDomSnapshot(message.payload as unknown as DomSnapshot, sender, state);
+        break;
+
+      case 'EXECUTE_TOOL':
+        void handleExecuteTool(
+          message.payload as unknown as ExecuteToolPayload,
+          sender,
+          sendResponse,
+          state,
+        );
+        return true; // Keep sendResponse channel open for async
+
+      case 'GET_TOOLS':
+        handleGetTools(sendResponse, state);
+        break;
+
+      case 'GET_CONFIG':
+        handleGetConfig(sendResponse, state);
+        break;
+
+      default:
+        // Unknown message type — ignore
+        break;
+    }
+  };
+}
+
+// ─── Bootstrap (runs when loaded as service worker) ─────
+
+export function initServiceWorker(chromeApi: typeof chrome): ServiceWorkerState {
+  const state: ServiceWorkerState = {
+    tabContexts: new Map(),
+    toolDefinitions: [],
+    config: {
+      bridgeApiUrl: 'http://localhost:3000',
+    },
+  };
+
+  const router = createServiceWorkerMessageRouter(state, chromeApi);
+  chromeApi.runtime.onMessage.addListener(router);
+
+  // Load config from local storage
+  chromeApi.storage.local.get(['bridge_api_url']).then((result: Record<string, unknown>) => {
+    if (typeof result['bridge_api_url'] === 'string') {
+      state.config.bridgeApiUrl = result['bridge_api_url'];
+    }
+  }).catch(() => {
+    // Use default config
+  });
+
+  return state;
+}

--- a/packages/extension/vitest.config.ts
+++ b/packages/extension/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: 'node',
+    include: ['src/**/__tests__/**/*.test.ts', 'src/**/__tests__/**/*.test.tsx'],
+  },
+});


### PR DESCRIPTION
## Summary
- Implement extension service worker with message routing for PAGE_DETECTED, DOM_SNAPSHOT, EXECUTE_TOOL, GET_TOOLS, and GET_CONFIG
- Manages per-tab context state and persists to chrome.storage.session
- Routes tool execution calls to the bridge backend API
- 17 unit tests covering all handlers and the message router

## Test plan
- [x] All 17 service worker unit tests pass
- [x] ESLint passes with zero warnings
- [x] TypeScript compilation passes

Closes #16