### PR TITLE
feat(extension): implement content script

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -2,7 +2,24 @@
   "name": "@webmcp-bridge/extension",
   "version": "0.1.0",
   "description": "Chrome Extension (Manifest V3) — Capture + Execute modes",
-  "scripts": { "build": "vite build", "dev": "vite build --watch", "test": "vitest run" },
-  "dependencies": { "@webmcp-bridge/core": "*", "react": "^18.2.0", "react-dom": "^18.2.0" },
-  "devDependencies": { "@types/chrome": "^0.0.260", "@types/react": "^18.2.0", "@types/react-dom": "^18.2.0", "@vitejs/plugin-react": "^4.2.0", "vite": "^5.1.0", "vitest": "^1.2.0", "typescript": "^5.3.0" }
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@webmcp-bridge/core": "*",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/chrome": "^0.0.260",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "jsdom": "^28.1.0",
+    "typescript": "^5.3.0",
+    "vite": "^5.1.0",
+    "vitest": "^1.2.0"
+  }
 }

--- a/packages/extension/src/content-script/__tests__/content-script.test.ts
+++ b/packages/extension/src/content-script/__tests__/content-script.test.ts
@@ -1,0 +1,279 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+  notifyPageChange,
+  captureDomSnapshot,
+  captureInteractiveElements,
+  generateXPath,
+  setupPageNavigationDetection,
+  setupDomObserver,
+  type ContentScriptDeps,
+} from '../index.js';
+
+// ─── Mock chrome API ───────────────────────────────────
+
+function createMockChrome() {
+  return {
+    runtime: {
+      sendMessage: vi.fn(),
+    },
+  };
+}
+
+function createMockDeps(overrides?: Partial<ContentScriptDeps>): ContentScriptDeps {
+  return {
+    chrome: createMockChrome() as unknown as typeof chrome,
+    window: globalThis.window,
+    document: globalThis.document,
+    ...overrides,
+  };
+}
+
+// ─── Tests ─────────────────────────────────────────────
+
+describe('Content Script', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('notifyPageChange', () => {
+    it('sends PAGE_DETECTED message via chrome runtime', () => {
+      const deps = createMockDeps();
+
+      notifyPageChange(deps);
+
+      expect(deps.chrome.runtime.sendMessage).toHaveBeenCalledWith({
+        type: 'PAGE_DETECTED',
+        payload: expect.objectContaining({
+          url: expect.any(String),
+          title: expect.any(String),
+          timestamp: expect.any(Number),
+        }),
+      });
+    });
+
+    it('includes current URL in the payload', () => {
+      const deps = createMockDeps();
+
+      notifyPageChange(deps);
+
+      const call = (deps.chrome.runtime.sendMessage as ReturnType<typeof vi.fn>).mock.calls[0] as unknown[];
+      const message = call[0] as { payload: { url: string } };
+      expect(message.payload.url).toBe(window.location.href);
+    });
+  });
+
+  describe('captureInteractiveElements', () => {
+    it('captures buttons', () => {
+      document.body.innerHTML = '<button id="btn1">Click me</button>';
+
+      const elements = captureInteractiveElements(document);
+
+      expect(elements.length).toBe(1);
+      expect(elements[0]!.tag).toBe('button');
+      expect(elements[0]!.text).toBe('Click me');
+    });
+
+    it('captures inputs', () => {
+      document.body.innerHTML = '<input id="name" type="text" aria-label="Name" />';
+
+      const elements = captureInteractiveElements(document);
+
+      expect(elements.length).toBe(1);
+      expect(elements[0]!.tag).toBe('input');
+      expect(elements[0]!.ariaLabel).toBe('Name');
+    });
+
+    it('captures select elements', () => {
+      document.body.innerHTML = '<select id="color"><option>Red</option></select>';
+
+      const elements = captureInteractiveElements(document);
+
+      expect(elements.length).toBe(1);
+      expect(elements[0]!.tag).toBe('select');
+    });
+
+    it('captures anchor elements', () => {
+      document.body.innerHTML = '<a href="/about">About</a>';
+
+      const elements = captureInteractiveElements(document);
+
+      expect(elements.length).toBe(1);
+      expect(elements[0]!.tag).toBe('a');
+      expect(elements[0]!.text).toBe('About');
+    });
+
+    it('captures elements with role attribute', () => {
+      document.body.innerHTML = '<div role="tab">Tab 1</div>';
+
+      const elements = captureInteractiveElements(document);
+
+      expect(elements.length).toBe(1);
+      expect(elements[0]!.tag).toBe('div');
+    });
+
+    it('limits to 500 elements', () => {
+      let html = '';
+      for (let i = 0; i < 600; i++) {
+        html += `<button id="btn${i}">B${i}</button>`;
+      }
+      document.body.innerHTML = html;
+
+      const elements = captureInteractiveElements(document);
+
+      expect(elements.length).toBe(500);
+    });
+
+    it('truncates text content to 100 chars', () => {
+      const longText = 'A'.repeat(200);
+      document.body.innerHTML = `<button>${longText}</button>`;
+
+      const elements = captureInteractiveElements(document);
+
+      expect(elements[0]!.text!.length).toBeLessThanOrEqual(100);
+    });
+  });
+
+  describe('generateXPath', () => {
+    it('generates xpath for element with id', () => {
+      document.body.innerHTML = '<div id="main"><span id="target">text</span></div>';
+      const el = document.getElementById('target')!;
+
+      const xpath = generateXPath(el);
+
+      expect(xpath).toContain('target');
+    });
+
+    it('generates xpath for element without id', () => {
+      document.body.innerHTML = '<div><span>first</span><span>second</span></div>';
+      const spans = document.querySelectorAll('span');
+      const el = spans[1]!;
+
+      const xpath = generateXPath(el);
+
+      expect(xpath).toBeTruthy();
+      expect(xpath.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('captureDomSnapshot', () => {
+    it('returns html, interactiveElements, and ariaMap', () => {
+      document.body.innerHTML = '<button aria-label="Save">Save</button>';
+
+      const snapshot = captureDomSnapshot(document);
+
+      expect(snapshot).toHaveProperty('html');
+      expect(snapshot).toHaveProperty('interactiveElements');
+      expect(snapshot).toHaveProperty('ariaMap');
+    });
+
+    it('limits html to 50000 characters', () => {
+      // Create a large DOM
+      let html = '';
+      for (let i = 0; i < 5000; i++) {
+        html += `<div class="item-${i}">Content for item number ${i} with some extra padding text</div>`;
+      }
+      document.body.innerHTML = html;
+
+      const snapshot = captureDomSnapshot(document);
+
+      expect(snapshot.html.length).toBeLessThanOrEqual(50000);
+    });
+
+    it('includes interactive elements in snapshot', () => {
+      document.body.innerHTML = '<input type="text" /><button>Go</button>';
+
+      const snapshot = captureDomSnapshot(document);
+
+      expect(snapshot.interactiveElements.length).toBe(2);
+    });
+  });
+
+  describe('setupPageNavigationDetection', () => {
+    it('patches history.pushState', () => {
+      const deps = createMockDeps();
+      const originalPushState = deps.window.history.pushState;
+
+      const cleanup = setupPageNavigationDetection(deps);
+
+      expect(deps.window.history.pushState).not.toBe(originalPushState);
+
+      cleanup();
+    });
+
+    it('patches history.replaceState', () => {
+      const deps = createMockDeps();
+      const originalReplaceState = deps.window.history.replaceState;
+
+      const cleanup = setupPageNavigationDetection(deps);
+
+      expect(deps.window.history.replaceState).not.toBe(originalReplaceState);
+
+      cleanup();
+    });
+
+    it('calls notifyPageChange when pushState is invoked', () => {
+      const deps = createMockDeps();
+
+      const cleanup = setupPageNavigationDetection(deps);
+
+      deps.window.history.pushState({}, '', '/new-url');
+
+      expect(deps.chrome.runtime.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'PAGE_DETECTED' }),
+      );
+
+      cleanup();
+    });
+
+    it('restores original methods on cleanup', () => {
+      const deps = createMockDeps();
+      const originalPushState = deps.window.history.pushState;
+      const originalReplaceState = deps.window.history.replaceState;
+
+      const cleanup = setupPageNavigationDetection(deps);
+      cleanup();
+
+      expect(deps.window.history.pushState).toBe(originalPushState);
+      expect(deps.window.history.replaceState).toBe(originalReplaceState);
+    });
+  });
+
+  describe('setupDomObserver', () => {
+    it('returns a disconnect function', () => {
+      const deps = createMockDeps();
+
+      const disconnect = setupDomObserver(deps, 50);
+
+      expect(typeof disconnect).toBe('function');
+      disconnect();
+    });
+
+    it('sends DOM_SNAPSHOT after debounce on DOM mutation', async () => {
+      const deps = createMockDeps();
+
+      const disconnect = setupDomObserver(deps, 50);
+
+      // Trigger a DOM mutation
+      const div = document.createElement('div');
+      div.id = 'new-element';
+      document.body.appendChild(div);
+
+      // Wait for debounce
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(deps.chrome.runtime.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'DOM_SNAPSHOT' }),
+      );
+
+      disconnect();
+    });
+  });
+});

--- a/packages/extension/src/content-script/index.ts
+++ b/packages/extension/src/content-script/index.ts
@@ -6,13 +6,215 @@
  * - Match current URL against loaded app url_patterns
  * - Take DOM snapshots for capture mode and healing
  * - Execute element interactions on behalf of service worker
- * - Inject navigator.modelContext polyfill (tool-injector)
  *
- * Implementation notes for agents:
+ * Implementation notes:
  * - Runs in page context (has DOM access)
  * - Communicates with service worker via chrome.runtime.sendMessage
  * - MutationObserver watches for significant DOM changes (not every mutation)
- * - Debounce DOM change notifications (500ms)
+ * - Debounce DOM change notifications (500ms default)
  */
-// TODO: Implement — see spec: docs/specs/extension-spec.md
-export {};
+
+// ─── Types ──────────────────────────────────────────────
+
+export interface InteractiveElement {
+  id: string;
+  tag: string;
+  ariaLabel?: string;
+  text?: string;
+  xPath: string;
+}
+
+export interface DomSnapshot {
+  html: string;
+  interactiveElements: InteractiveElement[];
+  ariaMap: Record<string, string[]>;
+}
+
+export interface ContentScriptDeps {
+  chrome: typeof chrome;
+  window: Window;
+  document: Document;
+}
+
+// ─── XPath generation ───────────────────────────────────
+
+export function generateXPath(element: Element): string {
+  if (element.id) {
+    return `//*[@id="${element.id}"]`;
+  }
+
+  const parts: string[] = [];
+  let current: Element | null = element;
+
+  while (current && current !== current.ownerDocument.documentElement) {
+    const parent: Element | null = current.parentElement;
+    if (!parent) {
+      parts.unshift(current.tagName.toLowerCase());
+      break;
+    }
+
+    const tagName = current.tagName;
+    const siblings = Array.from(parent.children).filter(
+      (child: Element) => child.tagName === tagName,
+    );
+
+    if (siblings.length > 1) {
+      const index = siblings.indexOf(current) + 1;
+      parts.unshift(`${current.tagName.toLowerCase()}[${index}]`);
+    } else {
+      parts.unshift(current.tagName.toLowerCase());
+    }
+
+    current = parent;
+  }
+
+  return '/' + parts.join('/');
+}
+
+// ─── Interactive element capture ────────────────────────
+
+export function captureInteractiveElements(doc: Document): InteractiveElement[] {
+  const selector = 'button, input, select, a, textarea, [role]';
+  const elements = doc.querySelectorAll(selector);
+
+  const result: InteractiveElement[] = [];
+
+  for (let i = 0; i < elements.length && result.length < 500; i++) {
+    const el = elements[i]!;
+
+    const id = el.id || `el_${i}`;
+    const tag = el.tagName.toLowerCase();
+    const ariaLabel = el.getAttribute('aria-label') ?? undefined;
+    const rawText = el.textContent ?? '';
+    const text = rawText.substring(0, 100) || undefined;
+    const xPath = generateXPath(el);
+
+    result.push({ id, tag, ariaLabel, text, xPath });
+  }
+
+  return result;
+}
+
+// ─── ARIA map ───────────────────────────────────────────
+
+function buildAriaMap(doc: Document): Record<string, string[]> {
+  const ariaMap: Record<string, string[]> = {};
+  const ariaElements = doc.querySelectorAll('[aria-label]');
+
+  for (const el of ariaElements) {
+    const label = el.getAttribute('aria-label');
+    if (label) {
+      const tag = el.tagName.toLowerCase();
+      if (!ariaMap[tag]) {
+        ariaMap[tag] = [];
+      }
+      ariaMap[tag].push(label);
+    }
+  }
+
+  return ariaMap;
+}
+
+// ─── DOM snapshot ───────────────────────────────────────
+
+export function captureDomSnapshot(doc: Document): DomSnapshot {
+  const fullHtml = doc.documentElement.outerHTML;
+  const html = fullHtml.substring(0, 50000);
+  const interactiveElements = captureInteractiveElements(doc);
+  const ariaMap = buildAriaMap(doc);
+
+  return { html, interactiveElements, ariaMap };
+}
+
+// ─── Page change notification ───────────────────────────
+
+export function notifyPageChange(deps: ContentScriptDeps): void {
+  deps.chrome.runtime.sendMessage({
+    type: 'PAGE_DETECTED',
+    payload: {
+      url: deps.window.location.href,
+      title: deps.document.title,
+      timestamp: Date.now(),
+    },
+  });
+}
+
+// ─── Page navigation detection ──────────────────────────
+
+export function setupPageNavigationDetection(deps: ContentScriptDeps): () => void {
+  const originalPushState = deps.window.history.pushState;
+  const originalReplaceState = deps.window.history.replaceState;
+
+  deps.window.history.pushState = function (
+    this: History,
+    ...args: Parameters<History['pushState']>
+  ): void {
+    originalPushState.apply(this, args);
+    notifyPageChange(deps);
+  };
+
+  deps.window.history.replaceState = function (
+    this: History,
+    ...args: Parameters<History['replaceState']>
+  ): void {
+    originalReplaceState.apply(this, args);
+    notifyPageChange(deps);
+  };
+
+  const popstateHandler = (): void => {
+    notifyPageChange(deps);
+  };
+
+  const loadHandler = (): void => {
+    notifyPageChange(deps);
+  };
+
+  deps.window.addEventListener('popstate', popstateHandler);
+  deps.window.addEventListener('load', loadHandler);
+
+  // Return cleanup function
+  return () => {
+    deps.window.history.pushState = originalPushState;
+    deps.window.history.replaceState = originalReplaceState;
+    deps.window.removeEventListener('popstate', popstateHandler);
+    deps.window.removeEventListener('load', loadHandler);
+  };
+}
+
+// ─── DOM Observer ───────────────────────────────────────
+
+export function setupDomObserver(deps: ContentScriptDeps, debounceMs = 500): () => void {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  const observer = new MutationObserver(() => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+
+    timeoutId = setTimeout(() => {
+      const snapshot = captureDomSnapshot(deps.document);
+      deps.chrome.runtime.sendMessage({
+        type: 'DOM_SNAPSHOT',
+        payload: snapshot,
+      });
+    }, debounceMs);
+  });
+
+  // Only observe if body exists
+  if (deps.document.body) {
+    observer.observe(deps.document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      characterData: false,
+      attributeFilter: ['class', 'id'],
+    });
+  }
+
+  return () => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+    observer.disconnect();
+  };
+}


### PR DESCRIPTION
## Summary
- Implement content script with MutationObserver-based DOM observation (debounced at 500ms)
- URL change detection via history.pushState/replaceState monkey-patching and popstate/load events
- Interactive element capture (buttons, inputs, selects, anchors, elements with role attributes)
- XPath generation and ARIA map building for accessibility
- DOM snapshot capture limited to 50KB HTML and 500 interactive elements
- 20 unit tests with jsdom environment

## Test plan
- [x] All 20 content script unit tests pass
- [x] All 17 service worker tests still pass
- [x] ESLint passes with zero warnings
- [x] TypeScript compilation passes

Closes #17