### PR TITLE
feat(python-sdk): implement Python PlaywrightDriver

### DIFF
--- a/packages/python-sdk/src/webmcp_bridge/drivers/playwright_driver.py
+++ b/packages/python-sdk/src/webmcp_bridge/drivers/playwright_driver.py
@@ -9,52 +9,331 @@ Maps bridge operations to Playwright's sync API:
 - screenshot → page.screenshot()
 
 Implementation notes for agents:
-- Constructor takes a Playwright Page (sync)
-- For async: create AsyncPlaywrightDriver (same interface, async methods)
+- Constructor takes a Playwright Page (sync), Browser, and BrowserContext
 - ARIA strategy → page.get_by_role(role, name=name)
 - Label strategy → page.get_by_label(text)
+- Text strategy → page.get_by_text(text)
 - CSS strategy → page.locator(selector)
+- JS strategy → page.evaluate(expression)
 """
 from __future__ import annotations
 
+import re
 from typing import Any
+
+
+def _escape_regex(s: str) -> str:
+    """Escape special regex characters in a string."""
+    return re.escape(s)
 
 
 class PlaywrightDriver:
     """Playwright-based BridgeDriver implementation."""
 
-    def __init__(self, page: Any) -> None:
+    def __init__(
+        self,
+        page: Any,
+        browser: Any | None = None,
+        context: Any | None = None,
+        timeout: int = 30000,
+    ) -> None:
         self._page = page
+        self._browser = browser
+        self._context = context
+        self._timeout = timeout
+        self._named_pages: dict[str, Any] = {}
+
+    # ─── Navigation ────────────────────────────────────
 
     def goto(self, url: str) -> None:
         """Navigate to URL."""
-        # TODO: Implement
-        raise NotImplementedError("See spec: docs/specs/playwright-driver-spec.md")
+        self._page.goto(url, wait_until="domcontentloaded")
+
+    def wait_for_navigation(self, url_pattern: str | None = None) -> None:
+        """Wait for navigation to complete."""
+        if url_pattern:
+            self._page.wait_for_url(url_pattern, timeout=self._timeout)
+        else:
+            self._page.wait_for_load_state("domcontentloaded", timeout=self._timeout)
+
+    # ─── Element Finding ──────────────────────────────
 
     def find_element(self, selectors: list[dict[str, Any]]) -> Any:
-        """Find element using selector chain."""
-        raise NotImplementedError
+        """Find element using selector chain with strategy fallback."""
+        for strategy in selectors:
+            try:
+                locator = self._map_strategy_to_locator(strategy)
+                if locator is None:
+                    continue
+                locator.first.wait_for(state="attached", timeout=5000)
+                return locator.first
+            except Exception:
+                continue
+        raise RuntimeError("Failed to find element with any strategy")
+
+    def _map_strategy_to_locator(self, strategy: dict[str, Any]) -> Any:
+        """Map a selector strategy to a Playwright locator."""
+        kind = strategy["strategy"]
+
+        if kind == "css":
+            return self._page.locator(strategy["selector"])
+
+        if kind == "aria":
+            name = strategy.get("name")
+            name_pattern = (
+                re.compile(_escape_regex(name), re.IGNORECASE) if name else None
+            )
+            return self._page.get_by_role(strategy["role"], name=name_pattern)
+
+        if kind == "label":
+            text_pattern = re.compile(_escape_regex(strategy["text"]), re.IGNORECASE)
+            return self._page.get_by_label(text_pattern)
+
+        if kind == "text":
+            if strategy.get("exact"):
+                return self._page.get_by_text(strategy["text"], exact=True)
+            text_pattern = re.compile(_escape_regex(strategy["text"]), re.IGNORECASE)
+            return self._page.get_by_text(text_pattern)
+
+        if kind == "js":
+            element = self._page.evaluate(strategy["expression"])
+            if element:
+                return element
+            return None
+
+        msg = f"Unknown selector strategy: {kind}"
+        raise ValueError(msg)
+
+    # ─── Interactions ─────────────────────────────────
 
     def click(self, element: Any) -> None:
-        raise NotImplementedError
+        """Click element."""
+        element.click(timeout=self._timeout)
 
-    def type_text(self, element: Any, text: str, clear: bool = True) -> None:
-        raise NotImplementedError
+    def double_click(self, element: Any) -> None:
+        """Double-click element."""
+        element.dblclick(timeout=self._timeout)
+
+    def type_text(
+        self,
+        element: Any,
+        text: str,
+        clear: bool = False,
+        delay: int | None = None,
+    ) -> None:
+        """Type text into element."""
+        if clear:
+            element.clear()
+        if delay:
+            element.press_sequentially(text, delay=delay)
+        else:
+            element.fill(text)
 
     def select(self, element: Any, value: str) -> None:
-        raise NotImplementedError
+        """Select option from dropdown."""
+        element.select_option(value)
+
+    def check(self, element: Any, state: bool) -> None:
+        """Check or uncheck a checkbox."""
+        if state:
+            element.check(timeout=self._timeout)
+        else:
+            element.uncheck(timeout=self._timeout)
+
+    def clear(self, element: Any) -> None:
+        """Clear element value."""
+        element.clear()
+
+    def hover(self, element: Any) -> None:
+        """Hover over element."""
+        element.hover(timeout=self._timeout)
+
+    def drag_drop(self, source: Any, target: Any) -> None:
+        """Drag source element to target element."""
+        source.drag_to(target)
+
+    def upload_file(self, element: Any, paths: list[str]) -> None:
+        """Upload files to input element."""
+        element.set_input_files(paths)
+
+    # ─── Reading ──────────────────────────────────────
 
     def read_text(self, selectors: list[dict[str, Any]]) -> str:
-        raise NotImplementedError
+        """Read text from element found by selectors."""
+        element = self.find_element(selectors)
+        text = element.text_content()
+        return (text or "").strip()
 
-    def read_pattern(self, selectors: list[dict[str, Any]], regex: str) -> str | None:
-        raise NotImplementedError
+    def read_pattern(
+        self, selectors: list[dict[str, Any]], regex: str
+    ) -> str | None:
+        """Read text and match a regex pattern."""
+        text = self.read_text(selectors)
+        pattern = re.compile(regex)
+        match = pattern.search(text)
+        if not match:
+            return None
+        return match.group(1) if match.lastindex and match.lastindex >= 1 else match.group(0)
+
+    # ─── Keyboard ─────────────────────────────────────
+
+    def press_key(self, key: str, modifiers: list[str] | None = None) -> None:
+        """Press a keyboard key with optional modifiers."""
+        if modifiers:
+            combo = "+".join(modifiers) + "+" + key
+        else:
+            combo = key
+        self._page.keyboard.press(combo)
+
+    def press_sequentially(
+        self, element: Any, text: str, delay: int | None = None
+    ) -> None:
+        """Type text character by character."""
+        element.press_sequentially(text, delay=delay)
+
+    # ─── Scrolling ────────────────────────────────────
+
+    def scroll(
+        self,
+        target: Any | str | None = None,
+        behavior: str = "instant",
+    ) -> None:
+        """Scroll page or element into view."""
+        if isinstance(target, str) and target == "top":
+            self._page.evaluate(f"window.scrollTo({{ top: 0, behavior: '{behavior}' }})")
+        elif isinstance(target, str) and target == "bottom":
+            self._page.evaluate(
+                f"window.scrollTo({{ top: document.body.scrollHeight, behavior: '{behavior}' }})"
+            )
+        elif target is not None and not isinstance(target, str):
+            target.scroll_into_view_if_needed(timeout=self._timeout)
+        else:
+            self._page.evaluate(f"window.scrollTo({{ top: 0, behavior: '{behavior}' }})")
+
+    # ─── Overlays ─────────────────────────────────────
+
+    def dismiss_overlay(self, strategy: dict[str, Any]) -> bool:
+        """Try to dismiss an overlay using the given strategy."""
+        try:
+            overlay_type = strategy["type"]
+            if overlay_type == "press_escape":
+                self._page.keyboard.press("Escape")
+            elif overlay_type == "click_close":
+                selector = strategy.get("selector")
+                if selector:
+                    self._page.locator(selector).click(timeout=3000)
+            elif overlay_type == "click_text":
+                texts = strategy.get("text", [])
+                for t in texts:
+                    try:
+                        self._page.get_by_text(t, exact=False).click(timeout=2000)
+                        break
+                    except Exception:
+                        continue
+            elif overlay_type == "remove_element":
+                selector = strategy.get("selector")
+                if selector:
+                    self._page.evaluate(
+                        f"document.querySelector('{selector}')?.remove()"
+                    )
+
+            wait_after = strategy.get("waitAfter")
+            if wait_after:
+                self._page.wait_for_timeout(wait_after)
+            return True
+        except Exception:
+            return False
+
+    # ─── Events ───────────────────────────────────────
+
+    def dispatch_event(
+        self, element: Any, event: str, detail: Any | None = None
+    ) -> None:
+        """Dispatch a DOM event on an element."""
+        event_init = {"detail": detail} if detail else None
+        element.dispatch_event(event, event_init)
+
+    # ─── Dialogs ──────────────────────────────────────
+
+    def handle_dialog(
+        self, action: str, prompt_text: str | None = None
+    ) -> str:
+        """Handle a JavaScript dialog (alert/confirm/prompt)."""
+        message = ""
+
+        def on_dialog(dialog: Any) -> None:
+            nonlocal message
+            message = dialog.message
+            if action == "accept":
+                dialog.accept(prompt_text)
+            else:
+                dialog.dismiss()
+
+        self._page.once("dialog", on_dialog)
+        return message
+
+    # ─── Waiting ──────────────────────────────────────
+
+    def wait_for(self, condition: dict[str, Any]) -> None:
+        """Wait for a condition to be met."""
+        cond_type = condition["type"]
+        value = condition.get("value")
+        timeout = condition.get("timeout", self._timeout)
+
+        if cond_type == "selector":
+            self._page.locator(value).wait_for(state="visible", timeout=timeout)
+        elif cond_type == "url":
+            self._page.wait_for_url(value, timeout=timeout)
+        elif cond_type == "timeout":
+            self._page.wait_for_timeout(value)
+        elif cond_type == "network_idle":
+            self._page.wait_for_load_state("networkidle", timeout=timeout)
+        else:
+            msg = f"Unknown wait condition type: {cond_type}"
+            raise ValueError(msg)
+
+    # ─── Diagnostics ──────────────────────────────────
 
     def screenshot(self) -> bytes:
-        raise NotImplementedError
+        """Take a full-page screenshot."""
+        return self._page.screenshot(full_page=True)  # type: ignore[no-any-return]
 
     def evaluate(self, js: str) -> Any:
-        raise NotImplementedError
+        """Evaluate JavaScript in the page context."""
+        return self._page.evaluate(js)
+
+    # ─── Context ──────────────────────────────────────
+
+    def get_page_context(self) -> dict[str, Any]:
+        """Get current page context information."""
+        return {
+            "url": self._page.url,
+            "title": self._page.title(),
+            "readyState": self._page.evaluate("document.readyState"),
+        }
+
+    # ─── Multi-tab ────────────────────────────────────
+
+    def get_named_page(self, name: str) -> Any:
+        """Get a previously created named page."""
+        if name not in self._named_pages:
+            msg = f"Page not found: {name}"
+            raise RuntimeError(msg)
+        page = self._named_pages[name]
+        page.bring_to_front()
+        return page
+
+    def create_page(self, name: str) -> Any:
+        """Create a new named page/tab."""
+        if self._context is None:
+            msg = "No browser context available"
+            raise RuntimeError(msg)
+        page = self._context.new_page()
+        self._named_pages[name] = page
+        return page
+
+    # ─── Legacy compatibility ─────────────────────────
 
     def wait_for_selector(self, selector: str, timeout: int = 10000) -> None:
-        raise NotImplementedError
+        """Wait for a CSS selector to be visible (legacy method)."""
+        self.wait_for({"type": "selector", "value": selector, "timeout": timeout})

--- a/packages/python-sdk/tests/test_playwright_driver.py
+++ b/packages/python-sdk/tests/test_playwright_driver.py
@@ -1,0 +1,485 @@
+"""Tests for PlaywrightDriver — Python implementation of BridgeDriver.
+
+Uses unittest.mock to mock Playwright Page, Browser, BrowserContext objects.
+Verifies all BridgeDriver methods delegate correctly to Playwright APIs.
+"""
+from __future__ import annotations
+
+import re
+from unittest.mock import MagicMock, PropertyMock, patch, call
+
+import pytest
+
+from webmcp_bridge.drivers.playwright_driver import PlaywrightDriver
+
+
+# ─── Fixtures ──────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_page() -> MagicMock:
+    page = MagicMock()
+    page.url = "https://example.com/test"
+    page.title.return_value = "Test Page"
+    page.evaluate.return_value = "complete"
+    return page
+
+
+@pytest.fixture
+def mock_browser() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_context() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def driver(
+    mock_page: MagicMock, mock_browser: MagicMock, mock_context: MagicMock
+) -> PlaywrightDriver:
+    return PlaywrightDriver(
+        page=mock_page, browser=mock_browser, context=mock_context, timeout=10000
+    )
+
+
+# ─── Constructor ───────────────────────────────────────────
+
+
+class TestConstructor:
+    def test_stores_page(self, driver: PlaywrightDriver, mock_page: MagicMock) -> None:
+        assert driver._page is mock_page
+
+    def test_stores_browser(self, driver: PlaywrightDriver, mock_browser: MagicMock) -> None:
+        assert driver._browser is mock_browser
+
+    def test_stores_context(self, driver: PlaywrightDriver, mock_context: MagicMock) -> None:
+        assert driver._context is mock_context
+
+    def test_default_timeout(self, mock_page: MagicMock, mock_browser: MagicMock, mock_context: MagicMock) -> None:
+        d = PlaywrightDriver(page=mock_page, browser=mock_browser, context=mock_context)
+        assert d._timeout == 30000
+
+    def test_custom_timeout(self, driver: PlaywrightDriver) -> None:
+        assert driver._timeout == 10000
+
+
+# ─── Navigation ────────────────────────────────────────────
+
+
+class TestGoto:
+    def test_navigates_to_url(self, driver: PlaywrightDriver, mock_page: MagicMock) -> None:
+        driver.goto("https://example.com")
+        mock_page.goto.assert_called_once_with("https://example.com", wait_until="domcontentloaded")
+
+
+class TestWaitForNavigation:
+    def test_waits_for_url_pattern(self, driver: PlaywrightDriver, mock_page: MagicMock) -> None:
+        driver.wait_for_navigation("https://example.com/**")
+        mock_page.wait_for_url.assert_called_once()
+
+    def test_waits_for_load_state_without_pattern(
+        self, driver: PlaywrightDriver, mock_page: MagicMock
+    ) -> None:
+        driver.wait_for_navigation()
+        mock_page.wait_for_load_state.assert_called_once()
+
+
+# ─── Element Finding ──────────────────────────────────────
+
+
+class TestFindElement:
+    def test_css_strategy(self, driver: PlaywrightDriver, mock_page: MagicMock) -> None:
+        locator = MagicMock()
+        first = MagicMock()
+        locator.first = first
+        mock_page.locator.return_value = locator
+
+        result = driver.find_element([{"strategy": "css", "selector": ".my-class"}])
+        mock_page.locator.assert_called_once_with(".my-class")
+        first.wait_for.assert_called_once()
+        assert result is first
+
+    def test_aria_strategy(self, driver: PlaywrightDriver, mock_page: MagicMock) -> None:
+        locator = MagicMock()
+        first = MagicMock()
+        locator.first = first
+        mock_page.get_by_role.return_value = locator
+
+        result = driver.find_element([{"strategy": "aria", "role": "button", "name": "Submit"}])
+        mock_page.get_by_role.assert_called_once()
+        assert result is first
+
+    def test_label_strategy(self, driver: PlaywrightDriver, mock_page: MagicMock) -> None:
+        locator = MagicMock()
+        first = MagicMock()
+        locator.first = first
+        mock_page.get_by_label.return_value = locator
+
+        result = driver.find_element([{"strategy": "label", "text": "Email"}])
+        mock_page.get_by_label.assert_called_once()
+        assert result is first
+
+    def test_text_strategy(self, driver: PlaywrightDriver, mock_page: MagicMock) -> None:
+        locator = MagicMock()
+        first = MagicMock()
+        locator.first = first
+        mock_page.get_by_text.return_value = locator
+
+        result = driver.find_element([{"strategy": "text", "text": "Hello"}])
+        mock_page.get_by_text.assert_called_once()
+        assert result is first
+
+    def test_text_exact_strategy(self, driver: PlaywrightDriver, mock_page: MagicMock) -> None:
+        locator = MagicMock()
+        first = MagicMock()
+        locator.first = first
+        mock_page.get_by_text.return_value = locator
+
+        driver.find_element([{"strategy": "text", "text": "Hello", "exact": True}])
+        mock_page.get_by_text.assert_called_once_with("Hello", exact=True)
+
+    def test_fallback_to_second_strategy(
+        self, driver: PlaywrightDriver, mock_page: MagicMock
+    ) -> None:
+        # First strategy fails
+        bad_locator = MagicMock()
+        bad_first = MagicMock()
+        bad_locator.first = bad_first
+        bad_first.wait_for.side_effect = Exception("Not found")
+        mock_page.locator.return_value = bad_locator
+
+        # Second strategy succeeds
+        good_locator = MagicMock()
+        good_first = MagicMock()
+        good_locator.first = good_first
+        mock_page.get_by_role.return_value = good_locator
+
+        result = driver.find_element([
+            {"strategy": "css", "selector": ".nonexistent"},
+            {"strategy": "aria", "role": "button", "name": "Submit"},
+        ])
+        assert result is good_first
+
+    def test_all_strategies_fail_raises(
+        self, driver: PlaywrightDriver, mock_page: MagicMock
+    ) -> None:
+        bad_locator = MagicMock()
+        bad_first = MagicMock()
+        bad_locator.first = bad_first
+        bad_first.wait_for.side_effect = Exception("Not found")
+        mock_page.locator.return_value = bad_locator
+
+        with pytest.raises(RuntimeError, match="Failed to find element"):
+            driver.find_element([{"strategy": "css", "selector": ".nonexistent"}])
+
+
+# ─── Interactions ──────────────────────────────────────────
+
+
+class TestClick:
+    def test_clicks_element(self, driver: PlaywrightDriver) -> None:
+        element = MagicMock()
+        driver.click(element)
+        element.click.assert_called_once_with(timeout=10000)
+
+
+class TestDoubleClick:
+    def test_double_clicks_element(self, driver: PlaywrightDriver) -> None:
+        element = MagicMock()
+        driver.double_click(element)
+        element.dblclick.assert_called_once_with(timeout=10000)
+
+
+class TestTypeText:
+    def test_fills_text(self, driver: PlaywrightDriver) -> None:
+        element = MagicMock()
+        driver.type_text(element, "hello")
+        element.fill.assert_called_once_with("hello")
+
+    def test_clears_before_filling(self, driver: PlaywrightDriver) -> None:
+        element = MagicMock()
+        driver.type_text(element, "hello", clear=True)
+        element.clear.assert_called_once()
+        element.fill.assert_called_once_with("hello")
+
+    def test_types_with_delay(self, driver: PlaywrightDriver) -> None:
+        element = MagicMock()
+        driver.type_text(element, "hi", delay=100)
+        element.press_sequentially.assert_called_once_with("hi", delay=100)
+
+
+class TestSelect:
+    def test_selects_option(self, driver: PlaywrightDriver) -> None:
+        element = MagicMock()
+        driver.select(element, "opt1")
+        element.select_option.assert_called_once_with("opt1")
+
+
+class TestCheck:
+    def test_check_true(self, driver: PlaywrightDriver) -> None:
+        element = MagicMock()
+        driver.check(element, True)
+        element.check.assert_called_once_with(timeout=10000)
+
+    def test_check_false(self, driver: PlaywrightDriver) -> None:
+        element = MagicMock()
+        driver.check(element, False)
+        element.uncheck.assert_called_once_with(timeout=10000)
+
+
+class TestClear:
+    def test_clears_element(self, driver: PlaywrightDriver) -> None:
+        element = MagicMock()
+        driver.clear(element)
+        element.clear.assert_called_once()
+
+
+class TestHover:
+    def test_hovers_element(self, driver: PlaywrightDriver) -> None:
+        element = MagicMock()
+        driver.hover(element)
+        element.hover.assert_called_once_with(timeout=10000)
+
+
+class TestDragDrop:
+    def test_drags_source_to_target(self, driver: PlaywrightDriver) -> None:
+        source = MagicMock()
+        target = MagicMock()
+        driver.drag_drop(source, target)
+        source.drag_to.assert_called_once_with(target)
+
+
+class TestUploadFile:
+    def test_sets_input_files(self, driver: PlaywrightDriver) -> None:
+        element = MagicMock()
+        driver.upload_file(element, ["/path/to/file.txt"])
+        element.set_input_files.assert_called_once_with(["/path/to/file.txt"])
+
+
+# ─── Reading ──────────────────────────────────────────────
+
+
+class TestReadText:
+    def test_reads_text_content(self, driver: PlaywrightDriver, mock_page: MagicMock) -> None:
+        locator = MagicMock()
+        first = MagicMock()
+        locator.first = first
+        first.text_content.return_value = "  Hello World  "
+        mock_page.locator.return_value = locator
+
+        result = driver.read_text([{"strategy": "css", "selector": ".text"}])
+        assert result == "Hello World"
+
+    def test_returns_empty_for_none(self, driver: PlaywrightDriver, mock_page: MagicMock) -> None:
+        locator = MagicMock()
+        first = MagicMock()
+        locator.first = first
+        first.text_content.return_value = None
+        mock_page.locator.return_value = locator
+
+        result = driver.read_text([{"strategy": "css", "selector": ".text"}])
+        assert result == ""
+
+
+class TestReadPattern:
+    def test_matches_pattern(self, driver: PlaywrightDriver, mock_page: MagicMock) -> None:
+        locator = MagicMock()
+        first = MagicMock()
+        locator.first = first
+        first.text_content.return_value = "3 items left"
+        mock_page.locator.return_value = locator
+
+        result = driver.read_pattern(
+            [{"strategy": "css", "selector": ".count"}], r"(\d+) items? left"
+        )
+        assert result == "3"
+
+    def test_returns_none_on_no_match(
+        self, driver: PlaywrightDriver, mock_page: MagicMock
+    ) -> None:
+        locator = MagicMock()
+        first = MagicMock()
+        locator.first = first
+        first.text_content.return_value = "no numbers here"
+        mock_page.locator.return_value = locator
+
+        result = driver.read_pattern(
+            [{"strategy": "css", "selector": ".count"}], r"(\d+) items? left"
+        )
+        assert result is None
+
+
+# ─── Keyboard ──────────────────────────────────────────────
+
+
+class TestPressKey:
+    def test_presses_single_key(self, driver: PlaywrightDriver, mock_page: MagicMock) -> None:
+        driver.press_key("Enter")
+        mock_page.keyboard.press.assert_called_once_with("Enter")
+
+    def test_presses_with_modifiers(
+        self, driver: PlaywrightDriver, mock_page: MagicMock
+    ) -> None:
+        driver.press_key("a", modifiers=["Control", "Shift"])
+        mock_page.keyboard.press.assert_called_once_with("Control+Shift+a")
+
+
+class TestPressSequentially:
+    def test_presses_sequentially(self, driver: PlaywrightDriver) -> None:
+        element = MagicMock()
+        driver.press_sequentially(element, "hello", delay=50)
+        element.press_sequentially.assert_called_once_with("hello", delay=50)
+
+
+# ─── Scrolling ─────────────────────────────────────────────
+
+
+class TestScroll:
+    def test_scroll_top(self, driver: PlaywrightDriver, mock_page: MagicMock) -> None:
+        driver.scroll("top")
+        mock_page.evaluate.assert_called()
+
+    def test_scroll_bottom(self, driver: PlaywrightDriver, mock_page: MagicMock) -> None:
+        driver.scroll("bottom")
+        mock_page.evaluate.assert_called()
+
+    def test_scroll_element(self, driver: PlaywrightDriver) -> None:
+        element = MagicMock()
+        driver.scroll(element)
+        element.scroll_into_view_if_needed.assert_called_once()
+
+
+# ─── Overlays ──────────────────────────────────────────────
+
+
+class TestDismissOverlay:
+    def test_press_escape(self, driver: PlaywrightDriver, mock_page: MagicMock) -> None:
+        result = driver.dismiss_overlay({"type": "press_escape"})
+        mock_page.keyboard.press.assert_called_once_with("Escape")
+        assert result is True
+
+    def test_returns_false_on_failure(
+        self, driver: PlaywrightDriver, mock_page: MagicMock
+    ) -> None:
+        mock_page.keyboard.press.side_effect = Exception("fail")
+        result = driver.dismiss_overlay({"type": "press_escape"})
+        assert result is False
+
+
+# ─── Events ────────────────────────────────────────────────
+
+
+class TestDispatchEvent:
+    def test_dispatches_event(self, driver: PlaywrightDriver) -> None:
+        element = MagicMock()
+        driver.dispatch_event(element, "change")
+        element.dispatch_event.assert_called_once_with("change", None)
+
+    def test_dispatches_with_detail(self, driver: PlaywrightDriver) -> None:
+        element = MagicMock()
+        driver.dispatch_event(element, "custom", detail={"key": "val"})
+        element.dispatch_event.assert_called_once_with("custom", {"detail": {"key": "val"}})
+
+
+# ─── Dialogs ───────────────────────────────────────────────
+
+
+class TestHandleDialog:
+    def test_accepts_dialog(self, driver: PlaywrightDriver, mock_page: MagicMock) -> None:
+        dialog = MagicMock()
+        dialog.message = "Are you sure?"
+        mock_page.once = MagicMock()
+
+        # Simulate dialog handler
+        def capture_handler(event_name: str, handler: object) -> None:
+            # Call the handler with the dialog mock
+            handler(dialog)  # type: ignore[operator]
+
+        mock_page.once.side_effect = capture_handler
+        result = driver.handle_dialog("accept")
+        assert result == "Are you sure?"
+
+
+# ─── Waiting ───────────────────────────────────────────────
+
+
+class TestWaitFor:
+    def test_wait_selector(self, driver: PlaywrightDriver, mock_page: MagicMock) -> None:
+        locator = MagicMock()
+        mock_page.locator.return_value = locator
+        driver.wait_for({"type": "selector", "value": ".loaded"})
+        locator.wait_for.assert_called_once()
+
+    def test_wait_timeout(self, driver: PlaywrightDriver, mock_page: MagicMock) -> None:
+        driver.wait_for({"type": "timeout", "value": 1000})
+        mock_page.wait_for_timeout.assert_called_once_with(1000)
+
+    def test_wait_url(self, driver: PlaywrightDriver, mock_page: MagicMock) -> None:
+        driver.wait_for({"type": "url", "value": "/dashboard"})
+        mock_page.wait_for_url.assert_called_once()
+
+    def test_wait_network_idle(self, driver: PlaywrightDriver, mock_page: MagicMock) -> None:
+        driver.wait_for({"type": "network_idle"})
+        mock_page.wait_for_load_state.assert_called_once()
+
+    def test_unknown_wait_type_raises(self, driver: PlaywrightDriver) -> None:
+        with pytest.raises(ValueError, match="Unknown wait condition"):
+            driver.wait_for({"type": "magic"})
+
+
+# ─── Diagnostics ───────────────────────────────────────────
+
+
+class TestScreenshot:
+    def test_returns_bytes(self, driver: PlaywrightDriver, mock_page: MagicMock) -> None:
+        mock_page.screenshot.return_value = b"\x89PNG"
+        result = driver.screenshot()
+        assert result == b"\x89PNG"
+        mock_page.screenshot.assert_called_once_with(full_page=True)
+
+
+class TestEvaluate:
+    def test_evaluates_js(self, driver: PlaywrightDriver, mock_page: MagicMock) -> None:
+        mock_page.evaluate.return_value = "Test Page"
+        result = driver.evaluate("document.title")
+        assert result == "Test Page"
+
+
+# ─── Context ───────────────────────────────────────────────
+
+
+class TestGetPageContext:
+    def test_returns_context(self, driver: PlaywrightDriver, mock_page: MagicMock) -> None:
+        mock_page.url = "https://example.com"
+        mock_page.title.return_value = "Test"
+        mock_page.evaluate.return_value = "complete"
+        ctx = driver.get_page_context()
+        assert ctx["url"] == "https://example.com"
+        assert ctx["title"] == "Test"
+        assert ctx["readyState"] == "complete"
+
+
+# ─── Multi-tab ─────────────────────────────────────────────
+
+
+class TestMultiTab:
+    def test_create_page(self, driver: PlaywrightDriver, mock_context: MagicMock) -> None:
+        new_page = MagicMock()
+        mock_context.new_page.return_value = new_page
+        result = driver.create_page("tab2")
+        assert result is new_page
+        mock_context.new_page.assert_called_once()
+
+    def test_get_named_page(self, driver: PlaywrightDriver, mock_context: MagicMock) -> None:
+        new_page = MagicMock()
+        mock_context.new_page.return_value = new_page
+        driver.create_page("tab2")
+        result = driver.get_named_page("tab2")
+        assert result is new_page
+        new_page.bring_to_front.assert_called_once()
+
+    def test_get_unknown_page_raises(self, driver: PlaywrightDriver) -> None:
+        with pytest.raises(RuntimeError, match="Page not found"):
+            driver.get_named_page("nonexistent")


### PR DESCRIPTION
## Summary
- Implements the full Python `PlaywrightDriver` mapping all BridgeDriver operations to Playwright's sync API
- Covers navigation, element finding with strategy fallback (aria, label, text, css, js), interactions (click, type, select, check, clear, hover, drag-drop, upload), reading, keyboard, scrolling, overlays, dialogs, events, waiting, screenshots, evaluate, multi-tab, and page context
- Adds 53 unit tests with mock Playwright objects covering all methods and edge cases

Closes #20

## Test plan
- [x] All 53 Python unit tests pass (`pytest tests/test_playwright_driver.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)