### PR TITLE
feat(extension): implement NLP router

### DIFF
--- a/packages/extension/src/nlp-router/__tests__/nlp-router.test.ts
+++ b/packages/extension/src/nlp-router/__tests__/nlp-router.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  routeUserCommand,
+  buildToolSelectionPrompt,
+  parseRouterResponse,
+  type NlpRouterConfig,
+  type ToolSummary,
+} from '../index.js';
+
+// ─── Test data ─────────────────────────────────────────
+
+const sampleTools: ToolSummary[] = [
+  {
+    name: 'create_todo',
+    description: 'Create a new todo item',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        title: { type: 'string', description: 'Todo title' },
+        priority: { type: 'string', description: 'Priority level', enum: ['low', 'medium', 'high'] },
+      },
+      required: ['title'],
+    },
+  },
+  {
+    name: 'delete_todo',
+    description: 'Delete a todo item by ID',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'Todo ID' },
+      },
+      required: ['id'],
+    },
+  },
+];
+
+const defaultConfig: NlpRouterConfig = {
+  bridgeApiUrl: 'http://localhost:3000',
+};
+
+// ─── Tests ─────────────────────────────────────────────
+
+describe('NLP Router', () => {
+  describe('buildToolSelectionPrompt', () => {
+    it('includes user command in the prompt', () => {
+      const prompt = buildToolSelectionPrompt('create a task called Buy Milk', sampleTools);
+      expect(prompt).toContain('create a task called Buy Milk');
+    });
+
+    it('includes tool names and descriptions', () => {
+      const prompt = buildToolSelectionPrompt('do something', sampleTools);
+      expect(prompt).toContain('create_todo');
+      expect(prompt).toContain('Create a new todo item');
+      expect(prompt).toContain('delete_todo');
+      expect(prompt).toContain('Delete a todo item by ID');
+    });
+
+    it('includes input schema info', () => {
+      const prompt = buildToolSelectionPrompt('do something', sampleTools);
+      expect(prompt).toContain('title');
+      expect(prompt).toContain('priority');
+    });
+
+    it('instructs LLM to respond with JSON', () => {
+      const prompt = buildToolSelectionPrompt('do something', sampleTools);
+      expect(prompt).toContain('JSON');
+    });
+  });
+
+  describe('parseRouterResponse', () => {
+    it('parses valid JSON response', () => {
+      const response = '{"toolName": "create_todo", "inputs": {"title": "Buy Milk"}}';
+      const result = parseRouterResponse(response);
+      expect(result).toEqual({ toolName: 'create_todo', inputs: { title: 'Buy Milk' } });
+    });
+
+    it('parses response with markdown code block', () => {
+      const response = '```json\n{"toolName": "create_todo", "inputs": {"title": "Test"}}\n```';
+      const result = parseRouterResponse(response);
+      expect(result).toEqual({ toolName: 'create_todo', inputs: { title: 'Test' } });
+    });
+
+    it('returns null for invalid JSON', () => {
+      const result = parseRouterResponse('not valid json');
+      expect(result).toBeNull();
+    });
+
+    it('returns null for JSON missing required fields', () => {
+      const result = parseRouterResponse('{"foo": "bar"}');
+      expect(result).toBeNull();
+    });
+
+    it('returns null for empty string', () => {
+      const result = parseRouterResponse('');
+      expect(result).toBeNull();
+    });
+
+    it('handles JSON embedded in surrounding text', () => {
+      const response = 'Here is my response: {"toolName": "delete_todo", "inputs": {"id": "abc123"}} Hope that helps!';
+      const result = parseRouterResponse(response);
+      expect(result).toEqual({ toolName: 'delete_todo', inputs: { id: 'abc123' } });
+    });
+  });
+
+  describe('routeUserCommand', () => {
+    let mockFetch: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockFetch = vi.fn();
+    });
+
+    it('sends request to bridge API NLP endpoint', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          toolName: 'create_todo',
+          inputs: { title: 'Buy Milk' },
+        }),
+      });
+
+      await routeUserCommand('create a task called Buy Milk', sampleTools, defaultConfig, mockFetch);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/nlp/route',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    });
+
+    it('returns routing result on success', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          toolName: 'create_todo',
+          inputs: { title: 'Buy Milk' },
+        }),
+      });
+
+      const result = await routeUserCommand('create a task called Buy Milk', sampleTools, defaultConfig, mockFetch);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.toolName).toBe('create_todo');
+        expect(result.value.inputs).toEqual({ title: 'Buy Milk' });
+      }
+    });
+
+    it('returns error on API failure', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      const result = await routeUserCommand('create task', sampleTools, defaultConfig, mockFetch);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain('Network error');
+      }
+    });
+
+    it('returns error on non-ok API response', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      });
+
+      const result = await routeUserCommand('create task', sampleTools, defaultConfig, mockFetch);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain('500');
+      }
+    });
+
+    it('includes tools in request body', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          toolName: 'create_todo',
+          inputs: { title: 'Test' },
+        }),
+      });
+
+      await routeUserCommand('create task Test', sampleTools, defaultConfig, mockFetch);
+
+      const requestBody = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+      expect(requestBody).toHaveProperty('prompt');
+      expect(requestBody).toHaveProperty('tools');
+      expect(requestBody.tools).toHaveLength(2);
+    });
+
+    it('handles empty tools list', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          toolName: '',
+          inputs: {},
+        }),
+      });
+
+      const result = await routeUserCommand('do something', [], defaultConfig, mockFetch);
+
+      expect(result.ok).toBe(true);
+    });
+  });
+});

--- a/packages/extension/src/nlp-router/index.ts
+++ b/packages/extension/src/nlp-router/index.ts
@@ -2,11 +2,166 @@
  * NLP Router — maps natural language user commands to tool calls.
  *
  * In Execute Mode, business users type commands like "close case 12345".
- * This module sends the command + available tool schemas to an LLM
- * and receives back a structured tool call.
+ * This module sends the command + available tool schemas to an LLM API
+ * and receives back a structured tool call with name and inputs.
  *
- * Uses Strands Agents (via a lightweight JS bridge or direct API call)
- * or any LLM provider configured by the user.
+ * The router constructs a prompt that includes the user command and
+ * available tool schemas, sends it to the bridge backend's NLP endpoint,
+ * and parses the structured response.
  */
-// TODO: Implement — see spec: docs/specs/nlp-router-spec.md
-export {};
+
+// ─── Types ──────────────────────────────────────────────
+
+export interface ToolSummary {
+  name: string;
+  description: string;
+  inputSchema: {
+    type: string;
+    properties?: Record<string, { type: string; description?: string; enum?: string[] }>;
+    required?: string[];
+  };
+}
+
+export interface RoutingResult {
+  toolName: string;
+  inputs: Record<string, unknown>;
+}
+
+export interface NlpRouterConfig {
+  bridgeApiUrl: string;
+}
+
+export type NlpRouterResult =
+  | { ok: true; value: RoutingResult }
+  | { ok: false; error: string };
+
+// ─── Prompt building ────────────────────────────────────
+
+export function buildToolSelectionPrompt(
+  userCommand: string,
+  tools: ToolSummary[],
+): string {
+  const toolDescriptions = tools.map((t) => {
+    const params = t.inputSchema.properties
+      ? Object.entries(t.inputSchema.properties)
+          .map(([name, schema]) => {
+            const required = t.inputSchema.required?.includes(name) ? ' (required)' : '';
+            const enumValues = schema.enum ? ` [${schema.enum.join(', ')}]` : '';
+            return `    - ${name}: ${schema.type}${enumValues}${required}${schema.description ? ' — ' + schema.description : ''}`;
+          })
+          .join('\n')
+      : '    (no parameters)';
+
+    return `- ${t.name}: ${t.description}\n  Parameters:\n${params}`;
+  }).join('\n\n');
+
+  return `You are a web automation assistant. The user has asked:
+
+"${userCommand}"
+
+Available tools:
+${toolDescriptions}
+
+Analyze the user's request and determine which tool to use. Extract parameter values from the user's command.
+
+Respond with valid JSON only:
+{
+  "toolName": "exact_tool_name",
+  "inputs": {
+    "param1": "value1"
+  }
+}
+
+Only respond with valid JSON. Do not include any other text.`;
+}
+
+// ─── Response parsing ───────────────────────────────────
+
+export function parseRouterResponse(response: string): RoutingResult | null {
+  if (!response || response.trim().length === 0) {
+    return null;
+  }
+
+  // Try to extract JSON from the response
+  let jsonStr = response.trim();
+
+  // Remove markdown code blocks if present
+  const codeBlockMatch = /```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/.exec(jsonStr);
+  if (codeBlockMatch?.[1]) {
+    jsonStr = codeBlockMatch[1].trim();
+  }
+
+  // Try to find JSON object in the text
+  if (!jsonStr.startsWith('{')) {
+    const jsonMatch = /\{[\s\S]*\}/.exec(jsonStr);
+    if (jsonMatch) {
+      jsonStr = jsonMatch[0];
+    } else {
+      return null;
+    }
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(jsonStr);
+
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      'toolName' in parsed &&
+      'inputs' in parsed &&
+      typeof (parsed as Record<string, unknown>).toolName === 'string' &&
+      typeof (parsed as Record<string, unknown>).inputs === 'object'
+    ) {
+      return {
+        toolName: (parsed as RoutingResult).toolName,
+        inputs: (parsed as RoutingResult).inputs,
+      };
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// ─── Route user command ─────────────────────────────────
+
+export async function routeUserCommand(
+  userCommand: string,
+  tools: ToolSummary[],
+  config: NlpRouterConfig,
+  fetchFn: typeof fetch = globalThis.fetch,
+): Promise<NlpRouterResult> {
+  const prompt = buildToolSelectionPrompt(userCommand, tools);
+
+  try {
+    const response = await fetchFn(`${config.bridgeApiUrl}/nlp/route`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt, tools }),
+    });
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: `NLP routing failed: ${response.status} ${response.statusText}`,
+      };
+    }
+
+    const data = await response.json() as RoutingResult;
+
+    return {
+      ok: true,
+      value: {
+        toolName: data.toolName,
+        inputs: data.inputs,
+      },
+    };
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      ok: false,
+      error: `NLP routing error: ${message}`,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Implement NLP router that maps natural language commands to structured tool calls
- Build structured prompts with available tool schemas and parameter descriptions
- Send prompts to bridge backend NLP endpoint for LLM-powered tool selection
- Parse JSON responses including markdown code blocks and JSON embedded in text
- 16 unit tests covering prompt building, response parsing, and API routing

## Test plan
- [x] All 16 NLP router tests pass
- [x] All 76 other extension tests pass (92 total)
- [x] ESLint passes with zero warnings
- [x] TypeScript compilation passes

Closes #24