### PR TITLE
feat(python-sdk): implement Python Bridge Core

### DIFF
--- a/packages/python-sdk/src/webmcp_bridge/bridge/bridge.py
+++ b/packages/python-sdk/src/webmcp_bridge/bridge/bridge.py
@@ -18,14 +18,19 @@ Usage:
 The Bridge:
 - Loads semantic YAML from config.semantic_path (or from registry)
 - Validates YAML against schemas
-- Provides execute(tool_name, inputs) → dict of captured outputs
-- Provides execute_workflow(name, inputs) → dict
-- Provides get_tool_schemas() → list for LLM function calling
-- Provides get_strands_tools() → list of @tool decorated callables for Strands Agent
+- Provides execute(tool_name, inputs) -> dict of captured outputs
+- Provides execute_workflow(name, inputs) -> dict
+- Provides get_tool_schemas() -> list for LLM function calling
+- Provides get_strands_tools() -> list of @tool decorated callables for Strands Agent
 """
 from __future__ import annotations
 
+import os
+import re
+from pathlib import Path
 from typing import Any
+
+import yaml
 
 from webmcp_bridge.bridge.config import BridgeConfig
 
@@ -41,23 +46,337 @@ class Bridge:
         """
         self._config = config
         self._driver = driver
-        # TODO: Load semantic store from config.semantic_path or registry
-        # TODO: Initialize selector resolver, result capturer, healing pipeline
 
-    def execute(self, tool_name: str, inputs: dict[str, Any]) -> dict[str, Any]:
-        """Execute a tool and return captured outputs."""
-        # TODO: Implement — load tool def, iterate steps, capture results
-        raise NotImplementedError("See spec: docs/specs/python-sdk-spec.md")
+        # Semantic store
+        self._apps: dict[str, dict[str, Any]] = {}
+        self._pages: dict[str, dict[str, Any]] = {}
+        self._tools: dict[str, dict[str, Any]] = {}
+        self._workflows: dict[str, dict[str, Any]] = {}
 
-    def execute_workflow(self, workflow_name: str, inputs: dict[str, Any]) -> dict[str, Any]:
-        """Execute a workflow and return aggregated outputs."""
-        raise NotImplementedError
+        # Load semantic definitions
+        self._load_semantic_store()
+
+    # ─── Semantic Store ────────────────────────────────
+
+    def _load_semantic_store(self) -> None:
+        """Load all YAML definitions from the semantic path."""
+        sem_path = Path(self._config.semantic_path)
+        if not sem_path.exists():
+            msg = f"Semantic path not found: {sem_path}"
+            raise FileNotFoundError(msg)
+
+        # Load app.yaml
+        app_file = sem_path / "app.yaml"
+        if app_file.exists():
+            with open(app_file) as f:
+                data = yaml.safe_load(f)
+            if data and "app" in data:
+                app_def = data["app"]
+                self._apps[app_def["id"]] = app_def
+
+        # Load pages/*.yaml
+        pages_dir = sem_path / "pages"
+        if pages_dir.exists():
+            for page_file in sorted(pages_dir.glob("*.yaml")):
+                with open(page_file) as f:
+                    data = yaml.safe_load(f)
+                if data and "page" in data:
+                    page_def = data["page"]
+                    self._pages[page_def["id"]] = page_def
+
+        # Load tools/*.yaml
+        tools_dir = sem_path / "tools"
+        if tools_dir.exists():
+            for tool_file in sorted(tools_dir.glob("*.yaml")):
+                with open(tool_file) as f:
+                    data = yaml.safe_load(f)
+                if data and "tool" in data:
+                    tool_def = data["tool"]
+                    self._tools[tool_def["name"]] = tool_def
+
+        # Load workflows/*.yaml
+        workflows_dir = sem_path / "workflows"
+        if workflows_dir.exists():
+            for wf_file in sorted(workflows_dir.glob("*.yaml")):
+                with open(wf_file) as f:
+                    data = yaml.safe_load(f)
+                if data and "workflow" in data:
+                    wf_def = data["workflow"]
+                    self._workflows[wf_def["name"]] = wf_def
+
+    # ─── Getters ──────────────────────────────────────
+
+    def get_app(self, app_id: str) -> dict[str, Any] | None:
+        """Get app definition by ID."""
+        return self._apps.get(app_id)
+
+    def get_page(self, page_id: str) -> dict[str, Any] | None:
+        """Get page definition by ID."""
+        return self._pages.get(page_id)
+
+    def get_tool(self, tool_name: str) -> dict[str, Any] | None:
+        """Get tool definition by name."""
+        return self._tools.get(tool_name)
+
+    # ─── Resolution ───────────────────────────────────
+
+    def resolve_field_ref(self, ref: str) -> dict[str, Any] | None:
+        """Resolve a field reference like 'page_id.fields.field_id'."""
+        parts = ref.split(".")
+        if len(parts) < 3 or parts[1] != "fields":
+            return None
+        page_id = parts[0]
+        field_id = parts[2]
+        page = self._pages.get(page_id)
+        if not page:
+            return None
+        for field in page.get("fields", []):
+            if field["id"] == field_id:
+                return field
+        return None
+
+    def resolve_output_ref(self, ref: str) -> dict[str, Any] | None:
+        """Resolve an output reference like 'page_id.outputs.output_id'."""
+        parts = ref.split(".")
+        if len(parts) < 3 or parts[1] != "outputs":
+            return None
+        page_id = parts[0]
+        output_id = parts[2]
+        page = self._pages.get(page_id)
+        if not page:
+            return None
+        for output in page.get("outputs", []):
+            if output["id"] == output_id:
+                return output
+        return None
+
+    # ─── Template Rendering ───────────────────────────
+
+    def _render_template(self, template: str, variables: dict[str, Any]) -> str:
+        """Render a {{variable}} template with given variables."""
+
+        def replacer(match: re.Match[str]) -> str:
+            expr = match.group(1).strip()
+            # Support nested access: app.base_url
+            parts = expr.split(".")
+            value: Any = variables
+            for part in parts:
+                if isinstance(value, dict):
+                    value = value.get(part)
+                else:
+                    return ""
+                if value is None:
+                    return ""
+            return str(value)
+
+        return re.sub(r"\{\{(.+?)\}\}", replacer, template)
+
+    # ─── Tool Schemas ─────────────────────────────────
 
     def get_tool_schemas(self) -> list[dict[str, Any]]:
         """Get all tool schemas for LLM function calling."""
-        raise NotImplementedError
+        schemas = []
+        for tool_def in self._tools.values():
+            schemas.append({
+                "name": tool_def["name"],
+                "description": tool_def["description"],
+                "inputSchema": tool_def["inputSchema"],
+            })
+        return schemas
+
+    # ─── Tool Execution ───────────────────────────────
+
+    def execute(self, tool_name: str, inputs: dict[str, Any]) -> dict[str, Any]:
+        """Execute a tool and return captured outputs."""
+        if self._driver is None:
+            msg = "No driver configured — cannot execute tools"
+            raise RuntimeError(msg)
+
+        tool_def = self._tools.get(tool_name)
+        if tool_def is None:
+            msg = f"Tool not found: {tool_name}"
+            raise KeyError(msg)
+
+        bridge = tool_def["bridge"]
+        page_id = bridge["page"]
+        page_def = self._pages.get(page_id)
+        if page_def is None:
+            msg = f"Page not found: {page_id}"
+            raise KeyError(msg)
+
+        # Build variable context
+        variables: dict[str, Any] = dict(inputs)
+
+        # Add app to variables
+        app_id = page_def.get("app")
+        if app_id:
+            app = self._apps.get(app_id)
+            if app:
+                variables["app"] = app
+
+        # Captured outputs
+        outputs: dict[str, Any] = {}
+
+        # Execute steps
+        for step in bridge["steps"]:
+            self._execute_step(step, variables, outputs, page_def)
+
+        # Apply returns mapping
+        if "returns" in bridge:
+            final_outputs: dict[str, Any] = {}
+            for key, template in bridge["returns"].items():
+                final_outputs[key] = self._render_template(template, variables)
+            return final_outputs
+
+        return outputs
+
+    def _execute_step(
+        self,
+        step: dict[str, Any],
+        variables: dict[str, Any],
+        outputs: dict[str, Any],
+        current_page: dict[str, Any],
+    ) -> None:
+        """Execute a single tool step."""
+        if "navigate" in step:
+            self._execute_navigate(step["navigate"], variables, current_page)
+        elif "interact" in step:
+            self._execute_interact(step["interact"], variables)
+        elif "capture" in step:
+            self._execute_capture(step["capture"], variables, outputs)
+        elif "wait" in step:
+            self._execute_wait(step["wait"])
+        elif "evaluate_js" in step:
+            self._driver.evaluate(step["evaluate_js"])
+
+    def _execute_navigate(
+        self,
+        navigate: dict[str, Any],
+        variables: dict[str, Any],
+        current_page: dict[str, Any],
+    ) -> None:
+        """Execute a navigate step."""
+        page_id = navigate["page"]
+        page_def = self._pages.get(page_id, current_page)
+
+        url_template = page_def.get("url_template", page_def.get("url_pattern", "/"))
+        url = self._render_template(url_template, variables)
+        self._driver.goto(url)
+
+        wait_for = page_def.get("wait_for")
+        if wait_for:
+            self._driver.wait_for({
+                "type": "selector",
+                "value": wait_for,
+                "timeout": self._config.navigation_timeout_ms,
+            })
+
+    def _execute_interact(
+        self,
+        interact: dict[str, Any],
+        variables: dict[str, Any],
+    ) -> None:
+        """Execute an interact step."""
+        field_ref = interact.get("field") or interact.get("target")
+        if not field_ref:
+            return
+
+        field_def = self.resolve_field_ref(field_ref)
+        if not field_def:
+            msg = f"Field not found: {field_ref}"
+            raise KeyError(msg)
+
+        # Find element
+        element = self._driver.find_element(field_def["selectors"])
+
+        # Determine action
+        action = interact.get("action", field_def.get("interaction", {}).get("type", "click"))
+
+        if action in ("fill", "type", "text_input"):
+            value_template = interact.get("value", "")
+            rendered_value = self._render_template(value_template, variables)
+            self._driver.type_text(element, rendered_value)
+        elif action == "click":
+            self._driver.click(element)
+        elif action == "select":
+            value_template = interact.get("value", "")
+            rendered_value = self._render_template(value_template, variables)
+            self._driver.select(element, rendered_value)
+        elif action == "check":
+            self._driver.check(element, True)
+        elif action == "clear":
+            self._driver.clear(element)
+        elif action == "hover":
+            self._driver.hover(element)
+        else:
+            # Default to click for action buttons
+            if field_def.get("type") == "action_button":
+                self._driver.click(element)
+
+    def _execute_capture(
+        self,
+        capture: dict[str, Any],
+        variables: dict[str, Any],
+        outputs: dict[str, Any],
+    ) -> None:
+        """Execute a capture step."""
+        output_ref = capture["from"]
+        store_as = capture["store_as"]
+
+        if capture.get("wait"):
+            self._driver.wait_for({"type": "timeout", "value": 500})
+
+        output_def = self.resolve_output_ref(output_ref)
+        if not output_def:
+            msg = f"Output not found: {output_ref}"
+            raise KeyError(msg)
+
+        # Read text from element
+        value = self._driver.read_text(output_def["selectors"])
+
+        variables[store_as] = value
+        outputs[store_as] = value
+
+    def _execute_wait(self, wait: int | str) -> None:
+        """Execute a wait step."""
+        if isinstance(wait, int):
+            duration_ms = wait
+        elif isinstance(wait, str):
+            duration_ms = self._parse_duration(wait)
+        else:
+            duration_ms = 1000
+        self._driver.wait_for({"type": "timeout", "value": duration_ms})
+
+    @staticmethod
+    def _parse_duration(duration: str) -> int:
+        """Parse a duration string like '500ms' or '2s' to milliseconds."""
+        ms_match = re.match(r"^(\d+)\s*ms$", duration)
+        if ms_match:
+            return int(ms_match.group(1))
+        s_match = re.match(r"^(\d+)\s*s$", duration)
+        if s_match:
+            return int(s_match.group(1)) * 1000
+        try:
+            return int(duration)
+        except ValueError:
+            return 5000
+
+    # ─── Workflow Execution ───────────────────────────
+
+    def execute_workflow(self, workflow_name: str, inputs: dict[str, Any]) -> dict[str, Any]:
+        """Execute a workflow and return aggregated outputs."""
+        wf = self._workflows.get(workflow_name)
+        if wf is None:
+            msg = f"Workflow not found: {workflow_name}"
+            raise KeyError(msg)
+        # Workflow execution is a future enhancement
+        msg = "Workflow execution not yet implemented"
+        raise NotImplementedError(msg)
+
+    # ─── Strands Integration ──────────────────────────
 
     def get_strands_tools(self) -> list[Any]:
         """Get Strands Agent-compatible @tool callables for all loaded tools."""
-        # TODO: Import from llm/strands_integration.py
-        raise NotImplementedError
+        # Deferred to Issue #22
+        from webmcp_bridge.llm.strands_integration import create_bridge_tools
+        return create_bridge_tools(self)

--- a/packages/python-sdk/tests/test_bridge.py
+++ b/packages/python-sdk/tests/test_bridge.py
@@ -1,21 +1,387 @@
-"""Tests for the Bridge class."""
+"""Tests for the Bridge class — Python Bridge Core."""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch, AsyncMock
+
 import pytest
+import yaml
+
+from webmcp_bridge.bridge.bridge import Bridge
+from webmcp_bridge.bridge.config import BridgeConfig
 
 
-class TestBridge:
-    def test_bridge_init_with_valid_config(self) -> None:
-        pass
-
-    def test_bridge_execute_tool_not_found(self) -> None:
-        pass
-
-    def test_bridge_get_tool_schemas(self) -> None:
-        pass
+# ─── Fixtures ──────────────────────────────────────────────
 
 
-class TestStrandsIntegration:
-    def test_create_bridge_tools(self) -> None:
-        pass
+APP_YAML = {
+    "app": {
+        "id": "test-app",
+        "name": "Test Application",
+        "base_url": "http://localhost:3000",
+        "url_patterns": ["http://localhost:3000/**"],
+    }
+}
 
-    def test_create_bridge_agent(self) -> None:
-        pass
+PAGE_YAML = {
+    "page": {
+        "id": "test_page",
+        "app": "test-app",
+        "url_pattern": "/",
+        "url_template": "{{app.base_url}}/",
+        "wait_for": ".page-ready",
+        "fields": [
+            {
+                "id": "name_input",
+                "label": "Name",
+                "type": "text",
+                "selectors": [{"strategy": "css", "selector": "#name"}],
+                "interaction": {"type": "text_input"},
+            },
+            {
+                "id": "submit_btn",
+                "label": "Submit",
+                "type": "action_button",
+                "selectors": [{"strategy": "css", "selector": "#submit"}],
+                "interaction": {"type": "click"},
+            },
+        ],
+        "outputs": [
+            {
+                "id": "result_text",
+                "label": "Result",
+                "selectors": [{"strategy": "css", "selector": ".result"}],
+            }
+        ],
+    }
+}
+
+TOOL_YAML = {
+    "tool": {
+        "name": "add_item",
+        "description": "Add a new item",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "text": {"type": "string", "description": "Item text"},
+            },
+            "required": ["text"],
+        },
+        "bridge": {
+            "page": "test_page",
+            "steps": [
+                {"navigate": {"page": "test_page"}},
+                {
+                    "interact": {
+                        "field": "test_page.fields.name_input",
+                        "action": "fill",
+                        "value": "{{text}}",
+                    }
+                },
+                {
+                    "interact": {
+                        "action": "click",
+                        "target": "test_page.fields.submit_btn",
+                    }
+                },
+                {
+                    "capture": {
+                        "from": "test_page.outputs.result_text",
+                        "store_as": "result",
+                        "wait": True,
+                    }
+                },
+            ],
+            "returns": {"result": "{{result}}"},
+        },
+    }
+}
+
+
+@pytest.fixture
+def semantic_dir() -> str:
+    """Create a temporary directory with semantic YAML files."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Write app.yaml
+        with open(os.path.join(tmpdir, "app.yaml"), "w") as f:
+            yaml.dump(APP_YAML, f)
+
+        # Write pages/
+        pages_dir = os.path.join(tmpdir, "pages")
+        os.makedirs(pages_dir)
+        with open(os.path.join(pages_dir, "test_page.yaml"), "w") as f:
+            yaml.dump(PAGE_YAML, f)
+
+        # Write tools/
+        tools_dir = os.path.join(tmpdir, "tools")
+        os.makedirs(tools_dir)
+        with open(os.path.join(tools_dir, "add_item.yaml"), "w") as f:
+            yaml.dump(TOOL_YAML, f)
+
+        yield tmpdir
+
+
+@pytest.fixture
+def mock_driver() -> MagicMock:
+    driver = MagicMock()
+    driver.goto = MagicMock()
+    driver.wait_for = MagicMock()
+    driver.find_element = MagicMock(return_value=MagicMock())
+    driver.click = MagicMock()
+    driver.type_text = MagicMock()
+    driver.read_text = MagicMock(return_value="mock result")
+    driver.read_pattern = MagicMock(return_value=None)
+    driver.evaluate = MagicMock()
+    driver.screenshot = MagicMock(return_value=b"\x89PNG")
+    return driver
+
+
+# ─── Initialization Tests ─────────────────────────────────
+
+
+class TestBridgeInit:
+    def test_init_with_valid_config(self, semantic_dir: str, mock_driver: MagicMock) -> None:
+        config = BridgeConfig(semantic_path=semantic_dir)
+        bridge = Bridge(config=config, driver=mock_driver)
+        assert bridge is not None
+
+    def test_loads_app_definition(self, semantic_dir: str, mock_driver: MagicMock) -> None:
+        config = BridgeConfig(semantic_path=semantic_dir)
+        bridge = Bridge(config=config, driver=mock_driver)
+        app = bridge.get_app("test-app")
+        assert app is not None
+        assert app["name"] == "Test Application"
+        assert app["base_url"] == "http://localhost:3000"
+
+    def test_loads_page_definition(self, semantic_dir: str, mock_driver: MagicMock) -> None:
+        config = BridgeConfig(semantic_path=semantic_dir)
+        bridge = Bridge(config=config, driver=mock_driver)
+        page = bridge.get_page("test_page")
+        assert page is not None
+        assert page["app"] == "test-app"
+        assert len(page["fields"]) == 2
+
+    def test_loads_tool_definition(self, semantic_dir: str, mock_driver: MagicMock) -> None:
+        config = BridgeConfig(semantic_path=semantic_dir)
+        bridge = Bridge(config=config, driver=mock_driver)
+        tool = bridge.get_tool("add_item")
+        assert tool is not None
+        assert tool["description"] == "Add a new item"
+
+    def test_init_without_driver(self, semantic_dir: str) -> None:
+        config = BridgeConfig(semantic_path=semantic_dir)
+        bridge = Bridge(config=config)
+        # Should work for schema-only mode
+        schemas = bridge.get_tool_schemas()
+        assert len(schemas) == 1
+
+    def test_invalid_semantic_path_raises(self) -> None:
+        config = BridgeConfig(semantic_path="/nonexistent/path")
+        with pytest.raises(FileNotFoundError):
+            Bridge(config=config)
+
+
+# ─── Tool Schema Tests ────────────────────────────────────
+
+
+class TestGetToolSchemas:
+    def test_returns_schemas(self, semantic_dir: str) -> None:
+        config = BridgeConfig(semantic_path=semantic_dir)
+        bridge = Bridge(config=config)
+        schemas = bridge.get_tool_schemas()
+        assert len(schemas) == 1
+        schema = schemas[0]
+        assert schema["name"] == "add_item"
+        assert schema["description"] == "Add a new item"
+        assert "inputSchema" in schema
+
+    def test_schema_has_correct_input_schema(self, semantic_dir: str) -> None:
+        config = BridgeConfig(semantic_path=semantic_dir)
+        bridge = Bridge(config=config)
+        schemas = bridge.get_tool_schemas()
+        input_schema = schemas[0]["inputSchema"]
+        assert input_schema["type"] == "object"
+        assert "text" in input_schema["properties"]
+        assert input_schema["required"] == ["text"]
+
+
+# ─── Tool Execution Tests ─────────────────────────────────
+
+
+class TestExecute:
+    def test_execute_tool_navigates(
+        self, semantic_dir: str, mock_driver: MagicMock
+    ) -> None:
+        config = BridgeConfig(semantic_path=semantic_dir)
+        bridge = Bridge(config=config, driver=mock_driver)
+        bridge.execute("add_item", {"text": "Buy milk"})
+        mock_driver.goto.assert_called_once_with("http://localhost:3000/")
+
+    def test_execute_tool_waits_for_page(
+        self, semantic_dir: str, mock_driver: MagicMock
+    ) -> None:
+        config = BridgeConfig(semantic_path=semantic_dir)
+        bridge = Bridge(config=config, driver=mock_driver)
+        bridge.execute("add_item", {"text": "Buy milk"})
+        mock_driver.wait_for.assert_called()
+
+    def test_execute_tool_types_text(
+        self, semantic_dir: str, mock_driver: MagicMock
+    ) -> None:
+        config = BridgeConfig(semantic_path=semantic_dir)
+        bridge = Bridge(config=config, driver=mock_driver)
+        bridge.execute("add_item", {"text": "Buy milk"})
+        mock_driver.type_text.assert_called_once()
+        # Check the text value passed
+        call_args = mock_driver.type_text.call_args
+        assert call_args[0][1] == "Buy milk"
+
+    def test_execute_tool_clicks_button(
+        self, semantic_dir: str, mock_driver: MagicMock
+    ) -> None:
+        config = BridgeConfig(semantic_path=semantic_dir)
+        bridge = Bridge(config=config, driver=mock_driver)
+        bridge.execute("add_item", {"text": "Buy milk"})
+        mock_driver.click.assert_called_once()
+
+    def test_execute_tool_captures_output(
+        self, semantic_dir: str, mock_driver: MagicMock
+    ) -> None:
+        config = BridgeConfig(semantic_path=semantic_dir)
+        bridge = Bridge(config=config, driver=mock_driver)
+        result = bridge.execute("add_item", {"text": "Buy milk"})
+        assert "result" in result
+        assert result["result"] == "mock result"
+
+    def test_execute_unknown_tool_raises(
+        self, semantic_dir: str, mock_driver: MagicMock
+    ) -> None:
+        config = BridgeConfig(semantic_path=semantic_dir)
+        bridge = Bridge(config=config, driver=mock_driver)
+        with pytest.raises(KeyError, match="Tool not found"):
+            bridge.execute("nonexistent_tool", {})
+
+    def test_execute_without_driver_raises(self, semantic_dir: str) -> None:
+        config = BridgeConfig(semantic_path=semantic_dir)
+        bridge = Bridge(config=config)
+        with pytest.raises(RuntimeError, match="No driver"):
+            bridge.execute("add_item", {"text": "test"})
+
+    def test_execute_with_wait_step(
+        self, semantic_dir: str, mock_driver: MagicMock
+    ) -> None:
+        """Test tool with an explicit wait step."""
+        # Create a tool with a wait step
+        tool_with_wait = {
+            "tool": {
+                "name": "wait_tool",
+                "description": "A tool that waits",
+                "inputSchema": {"type": "object", "properties": {}, "required": []},
+                "bridge": {
+                    "page": "test_page",
+                    "steps": [
+                        {"navigate": {"page": "test_page"}},
+                        {"wait": 500},
+                    ],
+                },
+            }
+        }
+        tools_dir = os.path.join(semantic_dir, "tools")
+        with open(os.path.join(tools_dir, "wait_tool.yaml"), "w") as f:
+            yaml.dump(tool_with_wait, f)
+
+        config = BridgeConfig(semantic_path=semantic_dir)
+        bridge = Bridge(config=config, driver=mock_driver)
+        result = bridge.execute("wait_tool", {})
+        # Wait should have been called for timeout
+        wait_calls = mock_driver.wait_for.call_args_list
+        found_timeout = any(
+            c[0][0].get("type") == "timeout" and c[0][0].get("value") == 500
+            for c in wait_calls
+        )
+        assert found_timeout
+
+    def test_execute_with_evaluate_js_step(
+        self, semantic_dir: str, mock_driver: MagicMock
+    ) -> None:
+        """Test tool with evaluate_js step."""
+        tool_with_js = {
+            "tool": {
+                "name": "js_tool",
+                "description": "A tool with JS eval",
+                "inputSchema": {"type": "object", "properties": {}, "required": []},
+                "bridge": {
+                    "page": "test_page",
+                    "steps": [
+                        {"navigate": {"page": "test_page"}},
+                        {"evaluate_js": "document.title"},
+                    ],
+                },
+            }
+        }
+        tools_dir = os.path.join(semantic_dir, "tools")
+        with open(os.path.join(tools_dir, "js_tool.yaml"), "w") as f:
+            yaml.dump(tool_with_js, f)
+
+        config = BridgeConfig(semantic_path=semantic_dir)
+        bridge = Bridge(config=config, driver=mock_driver)
+        bridge.execute("js_tool", {})
+        mock_driver.evaluate.assert_called_once_with("document.title")
+
+
+# ─── Field/Output Resolution Tests ────────────────────────
+
+
+class TestResolution:
+    def test_resolve_field_ref(self, semantic_dir: str) -> None:
+        config = BridgeConfig(semantic_path=semantic_dir)
+        bridge = Bridge(config=config)
+        field = bridge.resolve_field_ref("test_page.fields.name_input")
+        assert field is not None
+        assert field["id"] == "name_input"
+
+    def test_resolve_output_ref(self, semantic_dir: str) -> None:
+        config = BridgeConfig(semantic_path=semantic_dir)
+        bridge = Bridge(config=config)
+        output = bridge.resolve_output_ref("test_page.outputs.result_text")
+        assert output is not None
+        assert output["id"] == "result_text"
+
+    def test_resolve_unknown_field_returns_none(self, semantic_dir: str) -> None:
+        config = BridgeConfig(semantic_path=semantic_dir)
+        bridge = Bridge(config=config)
+        result = bridge.resolve_field_ref("test_page.fields.unknown")
+        assert result is None
+
+    def test_resolve_unknown_output_returns_none(self, semantic_dir: str) -> None:
+        config = BridgeConfig(semantic_path=semantic_dir)
+        bridge = Bridge(config=config)
+        result = bridge.resolve_output_ref("test_page.outputs.unknown")
+        assert result is None
+
+
+# ─── Template Rendering Tests ─────────────────────────────
+
+
+class TestTemplateRendering:
+    def test_renders_simple_variable(self, semantic_dir: str) -> None:
+        config = BridgeConfig(semantic_path=semantic_dir)
+        bridge = Bridge(config=config)
+        result = bridge._render_template("Hello {{name}}", {"name": "World"})
+        assert result == "Hello World"
+
+    def test_renders_nested_variable(self, semantic_dir: str) -> None:
+        config = BridgeConfig(semantic_path=semantic_dir)
+        bridge = Bridge(config=config)
+        result = bridge._render_template(
+            "{{app.base_url}}/", {"app": {"base_url": "http://localhost:3000"}}
+        )
+        assert result == "http://localhost:3000/"
+
+    def test_renders_missing_variable_as_empty(self, semantic_dir: str) -> None:
+        config = BridgeConfig(semantic_path=semantic_dir)
+        bridge = Bridge(config=config)
+        result = bridge._render_template("Hello {{missing}}", {})
+        assert result == "Hello "


### PR DESCRIPTION
## Summary
- Implements the `Bridge` class that loads semantic YAML definitions (app, pages, tools, workflows) and executes tools by iterating through steps (navigate, interact, capture, wait, evaluate_js)
- Includes template rendering for `{{variable}}` substitution, field/output reference resolution, and tool schema extraction for LLM function calling
- Adds 24 unit tests covering initialization, YAML loading, tool schemas, tool execution with all step types, field/output resolution, and template rendering

Closes #21

## Test plan
- [x] All 24 Bridge unit tests pass
- [x] All 77 Python SDK tests pass (Bridge + PlaywrightDriver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)