### PR TITLE
feat(extension): improve guide capture reliability

### DIFF
--- a/packages/extension/src/content-script/__tests__/recorder.test.ts
+++ b/packages/extension/src/content-script/__tests__/recorder.test.ts
@@ -2,8 +2,8 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { Recorder } from '../recorder.js';
-import type { RecordedAction } from '../recorder.js';
+
+import { Recorder, type RecordedAction } from '../recorder.js';
 
 // ─── Mock chrome API ────────────────────────────────────
 

--- a/packages/extension/src/content-script/__tests__/recorder.test.ts
+++ b/packages/extension/src/content-script/__tests__/recorder.test.ts
@@ -61,6 +61,11 @@ function fireInput(el: Element, value: string): void {
   el.dispatchEvent(event);
 }
 
+function fireChange(el: Element): void {
+  const event = new Event('change', { bubbles: true, composed: true });
+  el.dispatchEvent(event);
+}
+
 function fireKeydown(el: Element, key: string): void {
   const event = new KeyboardEvent('keydown', { key, bubbles: true, composed: true });
   el.dispatchEvent(event);
@@ -186,6 +191,215 @@ describe('Recorder', () => {
       const action: RecordedAction = sendAction.mock.calls[0][0];
       expect(action.type).toBe('input');
       expect(action.metadata?.inputValue).toBe('hello');
+      expect(action.metadata?.inputKind).toBe('text');
+    });
+
+    it('captures select changes immediately using selected option text', () => {
+      recorder.start();
+
+      const select = document.createElement('select');
+      select.setAttribute('aria-label', 'Filter 1');
+      const optionA = document.createElement('option');
+      optionA.value = 'status';
+      optionA.textContent = 'Status';
+      const optionB = document.createElement('option');
+      optionB.value = 'owner';
+      optionB.textContent = 'Owner';
+      select.append(optionA, optionB);
+      document.body.appendChild(select);
+
+      select.value = 'status';
+      fireChange(select);
+
+      expect(sendAction).toHaveBeenCalledTimes(1);
+      const action: RecordedAction = sendAction.mock.calls[0][0];
+      expect(action.type).toBe('input');
+      expect(action.element!.tag).toBe('select');
+      expect(action.metadata?.inputValue).toBe('Status');
+      expect(action.metadata?.inputKind).toBe('select');
+    });
+
+    it('deduplicates duplicate select input and change events', () => {
+      recorder.start();
+
+      const select = document.createElement('select');
+      select.setAttribute('aria-label', 'Filter 1');
+      const optionA = document.createElement('option');
+      optionA.value = 'status';
+      optionA.textContent = 'Status';
+      const optionB = document.createElement('option');
+      optionB.value = 'owner';
+      optionB.textContent = 'Owner';
+      select.append(optionA, optionB);
+      document.body.appendChild(select);
+
+      select.value = 'status';
+      fireInput(select, 'status');
+      fireChange(select);
+
+      expect(sendAction).toHaveBeenCalledTimes(1);
+      const action: RecordedAction = sendAction.mock.calls[0][0];
+      expect(action.type).toBe('input');
+      expect(action.metadata?.inputValue).toBe('Status');
+      expect(action.metadata?.inputKind).toBe('select');
+    });
+
+    it('captures option clicks as select changes on the controlling combobox', () => {
+      recorder.start();
+
+      const button = document.createElement('button');
+      button.setAttribute('aria-label', 'Filter 2');
+      button.setAttribute('aria-haspopup', 'listbox');
+      button.setAttribute('aria-controls', 'status-options');
+      document.body.appendChild(button);
+
+      const listbox = document.createElement('div');
+      listbox.id = 'status-options';
+      listbox.setAttribute('role', 'listbox');
+      const option = document.createElement('div');
+      option.setAttribute('role', 'option');
+      option.textContent = 'New';
+      listbox.appendChild(option);
+      document.body.appendChild(listbox);
+
+      fireClick(option);
+
+      expect(sendAction).toHaveBeenCalledTimes(1);
+      const action: RecordedAction = sendAction.mock.calls[0][0];
+      expect(action.type).toBe('input');
+      expect(action.element!.ariaLabel).toBe('Filter 2');
+      expect(action.element!.ariaRole).toBe('combobox');
+      expect(action.element!.selectors.aria).toEqual({ role: 'combobox', name: 'Filter 2' });
+      expect(action.metadata?.inputValue).toBe('New');
+      expect(action.metadata?.inputKind).toBe('select');
+    });
+
+    it('captures option clicks on an active expanded combobox without explicit popup linkage', () => {
+      recorder.start();
+
+      const button = document.createElement('button');
+      button.setAttribute('aria-label', 'Filter 1');
+      button.setAttribute('aria-haspopup', 'listbox');
+      button.setAttribute('aria-expanded', 'true');
+      button.tabIndex = 0;
+      document.body.appendChild(button);
+      button.focus();
+
+      const listbox = document.createElement('div');
+      listbox.setAttribute('role', 'listbox');
+      const option = document.createElement('div');
+      option.setAttribute('role', 'option');
+      option.textContent = 'Status';
+      listbox.appendChild(option);
+      document.body.appendChild(listbox);
+
+      fireClick(option);
+
+      expect(sendAction).toHaveBeenCalledTimes(1);
+      const action: RecordedAction = sendAction.mock.calls[0][0];
+      expect(action.type).toBe('input');
+      expect(action.element!.ariaLabel).toBe('Filter 1');
+      expect(action.element!.ariaRole).toBe('combobox');
+      expect(action.metadata?.inputValue).toBe('Status');
+      expect(action.metadata?.inputKind).toBe('select');
+    });
+
+    it('matches popup controllers even when popup ids contain special characters', () => {
+      recorder.start();
+
+      const button = document.createElement('button');
+      button.setAttribute('aria-label', 'Filter 2');
+      button.setAttribute('aria-haspopup', 'listbox');
+      button.setAttribute('aria-controls', '995:0');
+      document.body.appendChild(button);
+
+      const listbox = document.createElement('div');
+      listbox.id = '995:0';
+      listbox.setAttribute('role', 'listbox');
+      const option = document.createElement('div');
+      option.setAttribute('role', 'option');
+      option.textContent = 'New';
+      listbox.appendChild(option);
+      document.body.appendChild(listbox);
+
+      fireClick(option);
+
+      expect(sendAction).toHaveBeenCalledTimes(1);
+      const action: RecordedAction = sendAction.mock.calls[0][0];
+      expect(action.type).toBe('input');
+      expect(action.element!.ariaLabel).toBe('Filter 2');
+      expect(action.metadata?.inputValue).toBe('New');
+    });
+
+    it('captures menuitemradio clicks as select input when controlled by a listbox-style combobox', () => {
+      recorder.start();
+
+      const button = document.createElement('button');
+      button.setAttribute('aria-label', 'Filter 1');
+      button.setAttribute('aria-haspopup', 'listbox');
+      button.setAttribute('aria-controls', 'status-menu');
+      button.setAttribute('aria-expanded', 'true');
+      document.body.appendChild(button);
+
+      const menu = document.createElement('div');
+      menu.id = 'status-menu';
+      menu.setAttribute('role', 'menu');
+      const item = document.createElement('div');
+      item.setAttribute('role', 'menuitemradio');
+      item.textContent = 'Status';
+      menu.appendChild(item);
+      document.body.appendChild(menu);
+
+      fireClick(item);
+
+      expect(sendAction).toHaveBeenCalledTimes(1);
+      const action: RecordedAction = sendAction.mock.calls[0][0];
+      expect(action.type).toBe('input');
+      expect(action.element!.ariaLabel).toBe('Filter 1');
+      expect(action.element!.ariaRole).toBe('combobox');
+      expect(action.metadata?.inputValue).toBe('Status');
+      expect(action.metadata?.inputKind).toBe('select');
+    });
+
+    it('keeps menu item clicks as click actions instead of coercing them into selects', () => {
+      recorder.start();
+
+      const button = document.createElement('button');
+      button.setAttribute('aria-label', 'Show Status column actions');
+      button.setAttribute('aria-haspopup', 'menu');
+      button.setAttribute('aria-expanded', 'true');
+      document.body.appendChild(button);
+
+      const menu = document.createElement('div');
+      menu.setAttribute('role', 'menu');
+      const item = document.createElement('div');
+      item.setAttribute('role', 'menuitemradio');
+      item.textContent = 'Sort by Status';
+      menu.appendChild(item);
+      document.body.appendChild(menu);
+
+      fireClick(item);
+
+      expect(sendAction).toHaveBeenCalledTimes(1);
+      const action: RecordedAction = sendAction.mock.calls[0][0];
+      expect(action.type).toBe('click');
+      expect(action.metadata?.inputKind).toBeUndefined();
+      expect(action.element!.text).toContain('Sort by Status');
+    });
+
+    it('deduplicates text input blur events when value has already been recorded', async () => {
+      recorder.start();
+      const input = createMockElement({ tagName: 'INPUT', type: 'text' }) as HTMLInputElement;
+
+      fireInput(input, 'hello');
+      await new Promise(resolve => setTimeout(resolve, 400));
+      fireChange(input);
+
+      expect(sendAction).toHaveBeenCalledTimes(1);
+      const action: RecordedAction = sendAction.mock.calls[0][0];
+      expect(action.type).toBe('input');
+      expect(action.metadata?.inputValue).toBe('hello');
+      expect(action.metadata?.inputKind).toBe('text');
     });
   });
 

--- a/packages/extension/src/content-script/index.ts
+++ b/packages/extension/src/content-script/index.ts
@@ -134,14 +134,17 @@ export function captureDomSnapshot(doc: Document): DomSnapshot {
 // ─── Page change notification ───────────────────────────
 
 export function notifyPageChange(deps: ContentScriptDeps): void {
-  deps.chrome.runtime.sendMessage({
-    type: 'PAGE_DETECTED',
-    payload: {
-      url: deps.window.location.href,
-      title: deps.document.title,
-      timestamp: Date.now(),
-    },
-  });
+  if (!deps.chrome.runtime?.id) return;
+  try {
+    deps.chrome.runtime.sendMessage({
+      type: 'PAGE_DETECTED',
+      payload: {
+        url: deps.window.location.href,
+        title: deps.document.title,
+        timestamp: Date.now(),
+      },
+    }).catch(() => {});
+  } catch { /* Extension context invalidated */ }
 }
 
 // ─── Page navigation detection ──────────────────────────
@@ -197,11 +200,14 @@ export function setupDomObserver(deps: ContentScriptDeps, debounceMs = 500): () 
     }
 
     timeoutId = setTimeout(() => {
-      const snapshot = captureDomSnapshot(deps.document);
-      deps.chrome.runtime.sendMessage({
-        type: 'DOM_SNAPSHOT',
-        payload: snapshot,
-      });
+      if (!deps.chrome.runtime?.id) return;
+      try {
+        const snapshot = captureDomSnapshot(deps.document);
+        deps.chrome.runtime.sendMessage({
+          type: 'DOM_SNAPSHOT',
+          payload: snapshot,
+        }).catch(() => {});
+      } catch { /* Extension context invalidated */ }
     }, debounceMs);
   });
 
@@ -228,7 +234,7 @@ export function setupDomObserver(deps: ContentScriptDeps, debounceMs = 500): () 
 // Auto-initialize when Chrome injects this content script.
 // Guard: only run in browser with chrome.runtime (not in test environment).
 
-if (typeof globalThis.chrome !== 'undefined' && globalThis.chrome?.runtime?.sendMessage) {
+if (typeof globalThis.chrome !== 'undefined' && typeof globalThis.chrome?.runtime?.sendMessage === 'function') {
   const deps: ContentScriptDeps = {
     chrome: globalThis.chrome,
     window: globalThis.window,

--- a/packages/extension/src/content-script/recorder.ts
+++ b/packages/extension/src/content-script/recorder.ts
@@ -676,36 +676,33 @@ export class Recorder {
   }
 
   private hookNavigation(): void {
-    const self = this;
     const originalPush = history.pushState;
     const originalReplace = history.replaceState;
+    const emitNavigationIfNeeded = (from: string, to: string): void => {
+      if (from !== to && this.recording) {
+        this.emitNavigation(from, to);
+        this.lastUrl = to;
+      }
+    };
 
     history.pushState = function (...args: Parameters<typeof history.pushState>) {
       const from = window.location.href;
       originalPush.apply(this, args);
-      const to = window.location.href;
-      if (from !== to && self.recording) {
-        self.emitNavigation(from, to);
-        self.lastUrl = to;
-      }
+      emitNavigationIfNeeded(from, window.location.href);
     };
 
     history.replaceState = function (...args: Parameters<typeof history.replaceState>) {
       const from = window.location.href;
       originalReplace.apply(this, args);
-      const to = window.location.href;
-      if (from !== to && self.recording) {
-        self.emitNavigation(from, to);
-        self.lastUrl = to;
-      }
+      emitNavigationIfNeeded(from, window.location.href);
     };
 
     window.addEventListener('popstate', () => {
-      if (!self.recording) return;
+      if (!this.recording) return;
       const newUrl = window.location.href;
-      if (newUrl !== self.lastUrl) {
-        self.emitNavigation(self.lastUrl, newUrl);
-        self.lastUrl = newUrl;
+      if (newUrl !== this.lastUrl) {
+        this.emitNavigation(this.lastUrl, newUrl);
+        this.lastUrl = newUrl;
       }
     });
   }

--- a/packages/extension/src/content-script/recorder.ts
+++ b/packages/extension/src/content-script/recorder.ts
@@ -45,6 +45,7 @@ export interface RecordedAction {
   element?: ElementContext;
   metadata?: {
     inputValue?: string;
+    inputKind?: 'text' | 'select' | 'checkbox' | 'radio';
     key?: string;
     fromUrl?: string;
     toUrl?: string;
@@ -63,6 +64,190 @@ function truncate(str: string | null | undefined, len: number): string | undefin
   if (!str) return undefined;
   const trimmed = str.trim();
   return trimmed.length > 0 ? trimmed.substring(0, len) : undefined;
+}
+
+function isComboboxLike(el: Element | null): boolean {
+  if (!el) return false;
+
+  const explicitRole = el.getAttribute('role')?.toLowerCase();
+  if (explicitRole === 'combobox') {
+    return true;
+  }
+
+  if (el instanceof HTMLSelectElement || el.tagName.toLowerCase() === 'select') {
+    return true;
+  }
+
+  const popupKind = (el.getAttribute('aria-haspopup') || '').toLowerCase();
+  const hasPopupLink =
+    el.hasAttribute('aria-controls') ||
+    el.hasAttribute('aria-owns') ||
+    el.hasAttribute('aria-expanded');
+
+  return popupKind === 'listbox' && hasPopupLink;
+}
+
+function inferAccessibleRole(el: Element): string | undefined {
+  const explicitRole = el.getAttribute('role');
+  if (explicitRole) {
+    return explicitRole;
+  }
+
+  if (isComboboxLike(el)) {
+    return 'combobox';
+  }
+
+  const tag = el.tagName.toLowerCase();
+  if (tag === 'button') return 'button';
+  if (tag === 'a') return 'link';
+  if (tag === 'textarea') return 'textbox';
+
+  if (tag === 'input') {
+    const type = (el as HTMLInputElement).type?.toLowerCase();
+    if (type === 'checkbox') return 'checkbox';
+    if (type === 'radio') return 'radio';
+    if (type === 'search') return 'searchbox';
+    return 'textbox';
+  }
+
+  return undefined;
+}
+
+function getInputKind(el: Element): 'text' | 'select' | 'checkbox' | 'radio' {
+  if (isComboboxLike(el)) {
+    return 'select';
+  }
+
+  const type = (el as HTMLInputElement).type?.toLowerCase();
+  if (type === 'checkbox') return 'checkbox';
+  if (type === 'radio') return 'radio';
+  return 'text';
+}
+
+function getInputValue(el: Element): string {
+  if (el instanceof HTMLSelectElement) {
+    const selectedOption = el.selectedOptions[0];
+    return truncate(selectedOption?.textContent || el.value, 200) || '';
+  }
+
+  if (el instanceof HTMLInputElement) {
+    if (el.type === 'checkbox' || el.type === 'radio') {
+      return el.checked ? 'true' : 'false';
+    }
+    return truncate(el.value, 200) || '';
+  }
+
+  if (el instanceof HTMLTextAreaElement) {
+    return truncate(el.value, 200) || '';
+  }
+
+  return truncate((el as HTMLInputElement).value || '', 200) || '';
+}
+
+function scoreSelectionController(candidate: Element, popup: Element, popupId?: string): number {
+  let score = 0;
+
+  if (popupId && (candidate.getAttribute('aria-controls') === popupId || candidate.getAttribute('aria-owns') === popupId)) {
+    score += 300;
+  }
+
+  if (candidate === document.activeElement) {
+    score += 180;
+  }
+
+  if (candidate.getAttribute('aria-expanded') === 'true') {
+    score += 120;
+  }
+
+  if (candidate.getAttribute('role')?.toLowerCase() === 'combobox') {
+    score += 100;
+  }
+
+  if ((candidate.getAttribute('aria-haspopup') || '').toLowerCase() === 'listbox') {
+    score += 90;
+  }
+
+  const candidateLabel = `${candidate.getAttribute('aria-label') || ''} ${candidate.textContent || ''}`.toLowerCase();
+  if (candidateLabel.includes('filter')) {
+    score += 40;
+  }
+
+  try {
+    const popupRect = popup.getBoundingClientRect();
+    const candidateRect = candidate.getBoundingClientRect();
+    const popupCenterX = popupRect.left + popupRect.width / 2;
+    const popupCenterY = popupRect.top + popupRect.height / 2;
+    const candidateCenterX = candidateRect.left + candidateRect.width / 2;
+    const candidateCenterY = candidateRect.top + candidateRect.height / 2;
+    const distance = Math.hypot(popupCenterX - candidateCenterX, popupCenterY - candidateCenterY);
+    score += Math.max(0, 80 - Math.round(distance / 8));
+  } catch {
+    // Ignore layout failures in synthetic environments.
+  }
+
+  return score;
+}
+
+function findSelectionSource(target: Element): { source: Element; selectedText: string } | null {
+  const optionEl = target.closest('option, [role="option"], [role="menuitemradio"], [role="radio"]');
+  if (!optionEl) return null;
+
+  const selectedText =
+    truncate(optionEl.getAttribute('aria-label'), 200) ||
+    truncate(optionEl.textContent, 200) ||
+    truncate(optionEl.getAttribute('data-value'), 200);
+
+  if (!selectedText) return null;
+
+  if (optionEl instanceof HTMLOptionElement) {
+    const selectEl = optionEl.closest('select');
+    if (selectEl) {
+      return { source: selectEl, selectedText };
+    }
+  }
+
+  const popup = optionEl.closest('[role="listbox"], [role="menu"]');
+  if (!popup) {
+    return null;
+  }
+
+  const popupId = popup.id || undefined;
+  const candidates = new Set<Element>();
+
+  if (popupId) {
+    for (const candidate of document.querySelectorAll('[aria-controls], [aria-owns]')) {
+      if (!(candidate instanceof Element)) continue;
+      if (candidate.getAttribute('aria-controls') === popupId || candidate.getAttribute('aria-owns') === popupId) {
+        candidates.add(candidate);
+      }
+    }
+  }
+
+  const activeEl = document.activeElement;
+  if (activeEl instanceof Element && isComboboxLike(activeEl)) {
+    candidates.add(activeEl);
+  }
+
+  for (const candidate of document.querySelectorAll(
+    '[role="combobox"], [aria-haspopup="listbox"][aria-expanded="true"], [aria-haspopup="listbox"][aria-controls], [aria-haspopup="listbox"][aria-owns]',
+  )) {
+    if (candidate instanceof Element && isComboboxLike(candidate)) {
+      candidates.add(candidate);
+    }
+  }
+
+  let bestCandidate: Element | null = null;
+  let bestScore = 0;
+
+  for (const candidate of candidates) {
+    const score = scoreSelectionController(candidate, popup, popupId);
+    if (score > bestScore) {
+      bestScore = score;
+      bestCandidate = candidate;
+    }
+  }
+
+  return bestCandidate ? { source: bestCandidate, selectedText } : null;
 }
 
 /**
@@ -200,7 +385,7 @@ function buildElementContext(el: Element, composedPath?: EventTarget[]): Element
   const tag = el.tagName.toLowerCase();
   const rect = el.getBoundingClientRect();
 
-  const ariaRole = el.getAttribute('role') || undefined;
+  const ariaRole = inferAccessibleRole(el);
   const ariaLabel = el.getAttribute('aria-label') || undefined;
   const ariaName = ariaLabel || truncate(el.textContent, 60);
 
@@ -265,13 +450,20 @@ export class Recorder {
   private actions: RecordedAction[] = [];
   private maxActions = 500;
   private inputDebounceTimers: Map<Element, ReturnType<typeof setTimeout>> = new Map();
+  private recentInputEmissions: WeakMap<Element, {
+    value: string;
+    kind: 'text' | 'select' | 'checkbox' | 'radio';
+    timestamp: number;
+  }> = new WeakMap();
   private inputDebounceMs = 300;
+  private inputDuplicateWindowMs = 2000;
   private lastUrl: string;
   private sendAction: (action: RecordedAction) => void;
 
   // Bound handlers for cleanup
   private boundClickHandler: (e: MouseEvent) => void;
   private boundInputHandler: (e: Event) => void;
+  private boundChangeHandler: (e: Event) => void;
   private boundKeyHandler: (e: KeyboardEvent) => void;
 
   constructor(sendAction: (action: RecordedAction) => void) {
@@ -280,6 +472,7 @@ export class Recorder {
 
     this.boundClickHandler = this.handleClick.bind(this);
     this.boundInputHandler = this.handleInput.bind(this);
+    this.boundChangeHandler = this.handleChange.bind(this);
     this.boundKeyHandler = this.handleKeypress.bind(this);
   }
 
@@ -288,10 +481,12 @@ export class Recorder {
     this.recording = true;
     this.actions = [];
     this.lastUrl = window.location.href;
+    this.recentInputEmissions = new WeakMap();
     actionCounter = 0;
 
     document.addEventListener('click', this.boundClickHandler, { capture: true });
     document.addEventListener('input', this.boundInputHandler, { capture: true });
+    document.addEventListener('change', this.boundChangeHandler, { capture: true });
     document.addEventListener('keydown', this.boundKeyHandler, { capture: true });
 
     // Hook navigation
@@ -304,6 +499,7 @@ export class Recorder {
 
     document.removeEventListener('click', this.boundClickHandler, { capture: true });
     document.removeEventListener('input', this.boundInputHandler, { capture: true });
+    document.removeEventListener('change', this.boundChangeHandler, { capture: true });
     document.removeEventListener('keydown', this.boundKeyHandler, { capture: true });
 
     // Clear debounce timers
@@ -311,6 +507,7 @@ export class Recorder {
       clearTimeout(timer);
     }
     this.inputDebounceTimers.clear();
+    this.recentInputEmissions = new WeakMap();
 
     return this.actions;
   }
@@ -336,6 +533,12 @@ export class Recorder {
     if (!(target instanceof Element)) return;
 
     const el = target as Element;
+    const selection = findSelectionSource(el);
+    if (selection) {
+      this.emitInputAction(selection.source, e.composedPath(), selection.selectedText, 'select');
+      return;
+    }
+
     const ctx = buildElementContext(el, e.composedPath());
 
     // Check if navigation happened
@@ -371,6 +574,12 @@ export class Recorder {
     if (!(target instanceof Element)) return;
 
     const el = target as Element;
+    const inputKind = getInputKind(el);
+
+    if (inputKind !== 'text') {
+      this.emitInputAction(el, e.composedPath(), getInputValue(el), inputKind);
+      return;
+    }
 
     // Debounce rapid input events for the same element
     const existing = this.inputDebounceTimers.get(el);
@@ -378,25 +587,60 @@ export class Recorder {
 
     const timer = setTimeout(() => {
       this.inputDebounceTimers.delete(el);
-
-      const ctx = buildElementContext(el, e.composedPath());
-      const inputValue = (el as HTMLInputElement).value || '';
-
-      const action: RecordedAction = {
-        id: generateId(),
-        type: 'input',
-        timestamp: Date.now(),
-        url: window.location.href,
-        element: ctx,
-        metadata: {
-          inputValue: inputValue.substring(0, 200),
-        },
-      };
-
-      this.emit(action);
+      this.emitInputAction(el, e.composedPath(), getInputValue(el), inputKind);
     }, this.inputDebounceMs);
 
     this.inputDebounceTimers.set(el, timer);
+  }
+
+  private handleChange(e: Event): void {
+    if (!this.recording) return;
+
+    const target = e.composedPath()[0];
+    if (!(target instanceof Element)) return;
+
+    const el = target as Element;
+    const inputKind = getInputKind(el);
+    this.emitInputAction(el, e.composedPath(), getInputValue(el), inputKind);
+  }
+
+  private emitInputAction(
+    el: Element,
+    composedPath: EventTarget[],
+    inputValue: string,
+    inputKind: 'text' | 'select' | 'checkbox' | 'radio',
+  ): void {
+    const now = Date.now();
+    const previous = this.recentInputEmissions.get(el);
+    if (
+      previous &&
+      previous.kind === inputKind &&
+      previous.value === inputValue &&
+      now - previous.timestamp < this.inputDuplicateWindowMs
+    ) {
+      return;
+    }
+
+    const ctx = buildElementContext(el, composedPath);
+
+    const action: RecordedAction = {
+      id: generateId(),
+      type: 'input',
+      timestamp: now,
+      url: window.location.href,
+      element: ctx,
+      metadata: {
+        inputValue,
+        inputKind,
+      },
+    };
+
+    this.recentInputEmissions.set(el, {
+      value: inputValue,
+      kind: inputKind,
+      timestamp: now,
+    });
+    this.emit(action);
   }
 
   private handleKeypress(e: KeyboardEvent): void {
@@ -476,7 +720,18 @@ export function initRecorder(): void {
     if (message.type === 'START_RECORDING') {
       if (!recorderInstance) {
         recorderInstance = new Recorder((action) => {
-          chrome.runtime.sendMessage({ type: 'ACTION_RECORDED', payload: action }).catch(() => {});
+          // Guard: chrome.runtime.id is undefined when extension context is invalidated
+          if (!chrome.runtime?.id) {
+            recorderInstance?.stop();
+            recorderInstance = null;
+            return;
+          }
+          try {
+            chrome.runtime.sendMessage({ type: 'ACTION_RECORDED', payload: action }).catch(() => {});
+          } catch {
+            recorderInstance?.stop();
+            recorderInstance = null;
+          }
         });
       }
       recorderInstance.start();

--- a/packages/extension/src/panel/builders/__tests__/yaml-builder.test.ts
+++ b/packages/extension/src/panel/builders/__tests__/yaml-builder.test.ts
@@ -1,0 +1,753 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CaptureSnapshot } from '../../reducer.js';
+import type { RecordedAction } from '../../../content-script/recorder.js';
+import {
+  buildAppDefinition,
+  buildPageDefinition,
+  buildToolDefinition,
+  deriveTemplateVariables,
+} from '../yaml-builder.js';
+
+function createClickAction(
+  url: string,
+  overrides: Partial<RecordedAction['element']> = {},
+): RecordedAction {
+  return {
+    id: `act_${Math.random().toString(36).slice(2)}`,
+    type: 'click',
+    timestamp: Date.now(),
+    url,
+    element: {
+      tag: 'button',
+      classes: [],
+      selectors: {},
+      ...overrides,
+    },
+  };
+}
+
+function createInputAction(
+  url: string,
+  value: string,
+  overrides: Partial<RecordedAction['element']> = {},
+  metadata: Partial<NonNullable<RecordedAction['metadata']>> = {},
+): RecordedAction {
+  return {
+    id: `act_${Math.random().toString(36).slice(2)}`,
+    type: 'input',
+    timestamp: Date.now(),
+    url,
+    metadata: { inputValue: value, ...metadata },
+    element: {
+      tag: 'input',
+      classes: [],
+      selectors: {},
+      ...overrides,
+    },
+  };
+}
+
+describe('yaml-builder', () => {
+  it('builds an app definition from recorded pages', () => {
+    const appDef = buildAppDefinition('revance_oce_fulldev', [
+      'https://revance.example/lightning/r/Account/001ABCDEF123456/view',
+      'https://revance.example/lightning/r/Account/001ABCDEF123456/related/Cases/view',
+    ]);
+
+    expect(appDef).toEqual({
+      app: {
+        id: 'revance_oce_fulldev',
+        name: 'Revance Oce Fulldev',
+        base_url: 'https://revance.example',
+        url_patterns: [
+          '/lightning/r/Account/*/view',
+          '/lightning/r/Account/*/related/Cases/view',
+        ],
+      },
+    });
+  });
+
+  it('derives template variables from record page URLs deterministically', () => {
+    expect(deriveTemplateVariables([
+      'https://revance.example/lightning/r/Account/001ABCDEF123456/view',
+      'https://revance.example/lightning/r/Case/500ABCDEF123456/view',
+    ])).toEqual({
+      '001ABCDEF123456': 'account_id',
+      '500ABCDEF123456': 'case_id',
+    });
+  });
+
+  it('deduplicates repeated field labels when building a page definition', () => {
+    const snapshot: CaptureSnapshot = {
+      url: 'https://revance.example/lightning/r/Account/001ABCDEF123456/view',
+      title: 'Account',
+      timestamp: Date.now(),
+      elements: [
+        {
+          id: 'details-tab-1',
+          tag: 'button',
+          text: 'Details',
+          ariaLabel: 'Details',
+          xPath: '//*[@id="details-tab-1"]',
+          cssSelector: '#details-tab-1',
+          label: 'Details',
+        },
+        {
+          id: 'details-tab-2',
+          tag: 'button',
+          text: 'Details',
+          ariaLabel: 'Details',
+          xPath: '//*[@id="details-tab-2"]',
+          cssSelector: '#details-tab-2',
+          label: 'Details',
+        },
+      ],
+    };
+
+    const pageDef = buildPageDefinition(snapshot, 'revance_oce_fulldev', {});
+
+    expect(pageDef.page.fields.map(field => field.id)).toEqual(['details', 'details_2']);
+  });
+
+  it('maps partial action labels back to real page field ids', () => {
+    const url = 'https://revance.example/lightning/r/Account/001ABCDEF123456/related/Cases/view';
+    const snapshot: CaptureSnapshot = {
+      url,
+      title: 'Related Cases',
+      timestamp: Date.now(),
+      elements: [
+        {
+          id: 'more-actions',
+          tag: 'button',
+          ariaLabel: 'Show more actions',
+          text: 'Show more actions',
+          xPath: '//*[@id="more-actions"]',
+          cssSelector: '#more-actions',
+          label: 'Show more actions',
+        },
+        {
+          id: 'quick-filters',
+          tag: 'button',
+          ariaLabel: 'Show quick filters',
+          text: 'Show quick filters',
+          xPath: '//*[@id="quick-filters"]',
+          cssSelector: '#quick-filters',
+          label: 'Show quick filters',
+        },
+      ],
+    };
+
+    const pageDef = buildPageDefinition(snapshot, 'revance_oce_fulldev', {
+      '001ABCDEF123456': 'account_id',
+    });
+
+    const toolDef = buildToolDefinition([
+      createClickAction(url, {
+        ariaLabel: 'Show more actions',
+        selectors: { css: '#more-actions', aria: { role: 'button', name: 'Show more actions' } },
+      }),
+      createClickAction(url, {
+        nearbyLabel: 'Filters',
+        text: 'Filters',
+        selectors: { css: 'button.filters-toggle' },
+      }),
+    ], {
+      [url]: snapshot,
+    }, {
+      name: 'salesforce_account_cases_navigator',
+      description: 'Navigate account cases',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          account_id: { type: 'string', description: 'Account ID' },
+        },
+        required: ['account_id'],
+      },
+      templateVariables: {
+        '001ABCDEF123456': 'account_id',
+      },
+    }, [pageDef]);
+
+    const interactFields = toolDef.tool.bridge.steps
+      .filter(step => 'interact' in step)
+      .map(step => (step.interact as { field: string }).field);
+
+    expect(interactFields).toEqual([
+      'account_related_cases_view.fields.show_more_actions',
+      'account_related_cases_view.fields.show_quick_filters',
+    ]);
+  });
+
+  it('skips unresolved actions instead of inventing placeholder field ids', () => {
+    const url = 'https://revance.example/lightning/r/Account/001ABCDEF123456/view';
+    const snapshot: CaptureSnapshot = {
+      url,
+      title: 'Account',
+      timestamp: Date.now(),
+      elements: [
+        {
+          id: 'details-tab',
+          tag: 'button',
+          ariaLabel: 'Details',
+          text: 'Details',
+          xPath: '//*[@id="details-tab"]',
+          cssSelector: '#details-tab',
+          label: 'Details',
+        },
+      ],
+    };
+
+    const pageDef = buildPageDefinition(snapshot, 'revance_oce_fulldev', {
+      '001ABCDEF123456': 'account_id',
+    });
+
+    const toolDef = buildToolDefinition([
+      createClickAction(url, {
+        text: 'Something ambiguous',
+        selectors: { css: 'button.unknown' },
+      }),
+    ], {
+      [url]: snapshot,
+    }, {
+      name: 'ambiguous_click',
+      description: 'Skip ambiguous click',
+      inputSchema: { type: 'object', properties: {}, required: [] },
+      templateVariables: {
+        '001ABCDEF123456': 'account_id',
+      },
+    }, [pageDef]);
+
+    const interactSteps = toolDef.tool.bridge.steps.filter(step => 'interact' in step);
+
+    expect(interactSteps).toHaveLength(0);
+    expect(JSON.stringify(toolDef)).not.toContain('.fields.el_');
+  });
+
+  it('uses select actions for captured picklist input and trims earlier navigation noise', () => {
+    const accountUrl = 'https://revance.example/lightning/r/Account/001ABCDEF123456/view';
+    const relatedCasesUrl = 'https://revance.example/lightning/r/Account/001ABCDEF123456/related/Cases/view';
+
+    const accountSnapshot: CaptureSnapshot = {
+      url: accountUrl,
+      title: 'Account',
+      timestamp: Date.now(),
+      elements: [
+        {
+          id: 'details-tab',
+          tag: 'button',
+          ariaLabel: 'Details',
+          text: 'Details',
+          xPath: '//*[@id="details-tab"]',
+          cssSelector: '#details-tab',
+          label: 'Details',
+        },
+      ],
+    };
+
+    const relatedSnapshot: CaptureSnapshot = {
+      url: relatedCasesUrl,
+      title: 'Related Cases',
+      timestamp: Date.now(),
+      elements: [
+        {
+          id: 'quick-filters',
+          tag: 'button',
+          ariaLabel: 'Show quick filters',
+          text: 'Show quick filters',
+          xPath: '//*[@id="quick-filters"]',
+          cssSelector: '#quick-filters',
+          label: 'Show quick filters',
+        },
+        {
+          id: 'filter-one',
+          tag: 'select',
+          ariaLabel: 'Filter 1',
+          text: 'Status',
+          xPath: '//*[@id="filter-one"]',
+          cssSelector: '#filter-one',
+          label: 'Filter 1',
+          value: '',
+        },
+        {
+          id: 'filter-two',
+          tag: 'select',
+          ariaLabel: 'Filter 2',
+          text: 'New',
+          xPath: '//*[@id="filter-two"]',
+          cssSelector: '#filter-two',
+          label: 'Filter 2',
+          value: '',
+        },
+      ],
+    };
+
+    const accountPageDef = buildPageDefinition(accountSnapshot, 'revance_oce_fulldev', {
+      '001ABCDEF123456': 'account_id',
+    });
+    const relatedPageDef = buildPageDefinition(relatedSnapshot, 'revance_oce_fulldev', {
+      '001ABCDEF123456': 'account_id',
+    });
+
+    const toolDef = buildToolDefinition([
+      createClickAction(accountUrl, {
+        ariaLabel: 'Details',
+        selectors: { css: '#details-tab', aria: { role: 'button', name: 'Details' } },
+      }),
+      createClickAction(relatedCasesUrl, {
+        ariaLabel: 'Show quick filters',
+        selectors: { css: '#quick-filters', aria: { role: 'button', name: 'Show quick filters' } },
+      }),
+      createInputAction(relatedCasesUrl, 'Status', {
+        tag: 'select',
+        ariaLabel: 'Filter 1',
+        selectors: { css: '#filter-one', aria: { role: 'combobox', name: 'Filter 1' } },
+      }, { inputKind: 'select' }),
+      createInputAction(relatedCasesUrl, 'New', {
+        tag: 'select',
+        ariaLabel: 'Filter 2',
+        selectors: { css: '#filter-two', aria: { role: 'combobox', name: 'Filter 2' } },
+      }, { inputKind: 'select' }),
+    ], {
+      [accountUrl]: accountSnapshot,
+      [relatedCasesUrl]: relatedSnapshot,
+    }, {
+      name: 'salesforce_filter_cases',
+      description: 'Filter cases by status',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          account_id: { type: 'string', description: 'Account ID' },
+        },
+        required: ['account_id'],
+      },
+      templateVariables: {
+        '001ABCDEF123456': 'account_id',
+      },
+    }, [accountPageDef, relatedPageDef]);
+
+    expect(toolDef.tool.bridge.steps).toEqual([
+      {
+        navigate: {
+          page: 'account_related_cases_view',
+          params: { account_id: '{{account_id}}' },
+        },
+      },
+      { wait: 2000 },
+      {
+        interact: {
+          field: 'account_related_cases_view.fields.show_quick_filters',
+          action: 'click',
+        },
+      },
+      { wait: 1000 },
+      {
+        interact: {
+          field: 'account_related_cases_view.fields.filter_1',
+          action: 'select',
+          value: 'Status',
+        },
+      },
+      { wait: 500 },
+      {
+        interact: {
+          field: 'account_related_cases_view.fields.filter_2',
+          action: 'select',
+          value: 'New',
+        },
+      },
+    ]);
+  });
+
+  it('drops redundant click steps before selecting a value on the same field', () => {
+    const relatedCasesUrl = 'https://revance.example/lightning/r/Account/001ABCDEF123456/related/Cases/view';
+
+    const relatedSnapshot: CaptureSnapshot = {
+      url: relatedCasesUrl,
+      title: 'Related Cases',
+      timestamp: Date.now(),
+      elements: [
+        {
+          id: 'filter-one',
+          tag: 'select',
+          ariaLabel: 'Filter 1',
+          text: 'Status',
+          xPath: '//*[@id="filter-one"]',
+          cssSelector: '#filter-one',
+          label: 'Filter 1',
+          value: '',
+        },
+      ],
+    };
+
+    const relatedPageDef = buildPageDefinition(relatedSnapshot, 'revance_oce_fulldev', {
+      '001ABCDEF123456': 'account_id',
+    });
+
+    const toolDef = buildToolDefinition([
+      createClickAction(relatedCasesUrl, {
+        tag: 'select',
+        ariaLabel: 'Filter 1',
+        selectors: { css: '#filter-one', aria: { role: 'combobox', name: 'Filter 1' } },
+      }),
+      createInputAction(relatedCasesUrl, 'Status', {
+        tag: 'select',
+        ariaLabel: 'Filter 1',
+        selectors: { css: '#filter-one', aria: { role: 'combobox', name: 'Filter 1' } },
+      }, { inputKind: 'select' }),
+    ], {
+      [relatedCasesUrl]: relatedSnapshot,
+    }, {
+      name: 'salesforce_filter_cases',
+      description: 'Filter cases by status',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          account_id: { type: 'string', description: 'Account ID' },
+        },
+        required: ['account_id'],
+      },
+      templateVariables: {
+        '001ABCDEF123456': 'account_id',
+      },
+    }, [relatedPageDef]);
+
+    expect(toolDef.tool.bridge.steps).toEqual([
+      {
+        navigate: {
+          page: 'account_related_cases_view',
+          params: { account_id: '{{account_id}}' },
+        },
+      },
+      { wait: 2000 },
+      {
+        interact: {
+          field: 'account_related_cases_view.fields.filter_1',
+          action: 'select',
+          value: 'Status',
+        },
+      },
+    ]);
+  });
+
+  it('prefers quick-filter semantics over nearby list controls in filter flows', () => {
+    const relatedCasesUrl = 'https://revance.example/lightning/r/Account/001ABCDEF123456/related/Cases/view';
+
+    const relatedSnapshot: CaptureSnapshot = {
+      url: relatedCasesUrl,
+      title: 'Related Cases',
+      timestamp: Date.now(),
+      elements: [
+        {
+          id: 'merge-cases',
+          tag: 'button',
+          ariaLabel: 'Merge Cases',
+          text: 'Merge Cases',
+          xPath: '//*[@id="merge-cases"]',
+          cssSelector: '#merge-cases',
+          label: 'Merge Cases',
+        },
+        {
+          id: 'sort-by-case',
+          tag: 'a',
+          ariaLabel: 'Sort by:Case',
+          text: 'Sort by:Case',
+          xPath: '//*[@id="sort-by-case"]',
+          cssSelector: '#sort-by-case',
+          label: 'Sort by:Case',
+        },
+        {
+          id: 'quick-filters',
+          tag: 'button',
+          ariaLabel: 'Show quick filters',
+          text: 'Show quick filters',
+          xPath: '//*[@id="quick-filters"]',
+          cssSelector: '#quick-filters',
+          label: 'Show quick filters',
+        },
+        {
+          id: 'status-actions',
+          tag: 'button',
+          ariaLabel: 'Show Status column actions',
+          text: 'Show Status column actions',
+          xPath: '//*[@id="status-actions"]',
+          cssSelector: '#status-actions',
+          label: 'Show Status column actions',
+        },
+        {
+          id: 'status-width',
+          tag: 'input',
+          ariaLabel: 'Status column width',
+          text: '',
+          xPath: '//*[@id="status-width"]',
+          cssSelector: '#status-width',
+          label: 'Status column width',
+          value: '',
+        },
+        {
+          id: 'new-status',
+          tag: 'button',
+          ariaLabel: 'New',
+          text: 'New',
+          xPath: '//*[@id="new-status"]',
+          cssSelector: '#new-status',
+          label: 'New',
+        },
+        {
+          id: 'filter-one',
+          tag: 'select',
+          ariaLabel: 'Filter 1',
+          text: '',
+          xPath: '//*[@id="filter-one"]',
+          cssSelector: '#filter-one',
+          label: 'Filter 1',
+          value: '',
+        },
+        {
+          id: 'filter-two',
+          tag: 'select',
+          ariaLabel: 'Filter 2',
+          text: '',
+          xPath: '//*[@id="filter-two"]',
+          cssSelector: '#filter-two',
+          label: 'Filter 2',
+          value: '',
+        },
+      ],
+    };
+
+    const relatedPageDef = buildPageDefinition(relatedSnapshot, 'revance_oce_fulldev', {
+      '001ABCDEF123456': 'account_id',
+    });
+
+    const toolDef = buildToolDefinition([
+      createClickAction(relatedCasesUrl, {
+        tag: 'button',
+        ariaLabel: 'Merge Cases',
+        selectors: { css: '#merge-cases', aria: { role: 'button', name: 'Merge Cases' } },
+      }),
+      createClickAction(relatedCasesUrl, {
+        tag: 'a',
+        ariaLabel: 'Sort by:Case',
+        text: 'Sort by:Case',
+        selectors: { css: '#sort-by-case', aria: { role: 'link', name: 'Sort by:Case' } },
+      }),
+      createClickAction(relatedCasesUrl, {
+        tag: 'button',
+        ariaLabel: 'Show quick filters',
+        selectors: { css: '#quick-filters', aria: { role: 'button', name: 'Show quick filters' } },
+      }),
+      createClickAction(relatedCasesUrl, {
+        tag: 'button',
+        ariaLabel: 'Show Status column actions',
+        selectors: { css: '#status-actions', aria: { role: 'button', name: 'Show Status column actions' } },
+      }),
+      createInputAction(relatedCasesUrl, '', {
+        tag: 'input',
+        ariaLabel: 'Status column width',
+        selectors: { css: '#status-width', aria: { role: 'textbox', name: 'Status column width' } },
+      }, { inputKind: 'text' }),
+      createClickAction(relatedCasesUrl, {
+        tag: 'button',
+        ariaLabel: 'New',
+        text: 'New',
+        selectors: { css: '#new-status', aria: { role: 'button', name: 'New' } },
+      }),
+    ], {
+      [relatedCasesUrl]: relatedSnapshot,
+    }, {
+      name: 'salesforce_filter_account_cases',
+      description: 'Filter related cases by status',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          account_id: { type: 'string', description: 'Account ID' },
+        },
+        required: ['account_id'],
+      },
+      templateVariables: {
+        '001ABCDEF123456': 'account_id',
+      },
+    }, [relatedPageDef]);
+
+    expect(toolDef.tool.bridge.steps).toEqual([
+      {
+        navigate: {
+          page: 'account_related_cases_view',
+          params: { account_id: '{{account_id}}' },
+        },
+      },
+      { wait: 2000 },
+      {
+        interact: {
+          field: 'account_related_cases_view.fields.show_quick_filters',
+          action: 'click',
+        },
+      },
+      { wait: 1000 },
+      {
+        interact: {
+          field: 'account_related_cases_view.fields.filter_1',
+          action: 'select',
+          value: 'Status',
+        },
+      },
+      { wait: 500 },
+      {
+        interact: {
+          field: 'account_related_cases_view.fields.filter_2',
+          action: 'select',
+          value: 'New',
+        },
+      },
+    ]);
+  });
+
+  it('uses the closest timestamped snapshot when multiple captures exist for the same URL', () => {
+    const relatedCasesUrl = 'https://revance.example/lightning/r/Account/001ABCDEF123456/related/Cases/view';
+
+    const baseSnapshot: CaptureSnapshot = {
+      url: relatedCasesUrl,
+      title: 'Related Cases',
+      timestamp: 1000,
+      elements: [
+        {
+          id: 'quick-filters',
+          tag: 'button',
+          ariaLabel: 'Show quick filters',
+          text: 'Show quick filters',
+          xPath: '//*[@id="quick-filters"]',
+          cssSelector: '#quick-filters',
+          label: 'Show quick filters',
+        },
+      ],
+    };
+
+    const overlaySnapshot: CaptureSnapshot = {
+      url: relatedCasesUrl,
+      title: 'Related Cases',
+      timestamp: 2000,
+      elements: [
+        ...baseSnapshot.elements,
+        {
+          id: 'status-actions',
+          tag: 'button',
+          ariaLabel: 'Show Status column actions',
+          text: 'Show Status column actions',
+          xPath: '//*[@id="status-actions"]',
+          cssSelector: '#status-actions',
+          label: 'Show Status column actions',
+        },
+        {
+          id: 'new-status',
+          tag: 'button',
+          ariaLabel: 'New',
+          text: 'New',
+          xPath: '//*[@id="new-status"]',
+          cssSelector: '#new-status',
+          label: 'New',
+        },
+        {
+          id: 'filter-one',
+          tag: 'select',
+          ariaLabel: 'Filter 1',
+          text: '',
+          xPath: '//*[@id="filter-one"]',
+          cssSelector: '#filter-one',
+          label: 'Filter 1',
+          value: '',
+        },
+        {
+          id: 'filter-two',
+          tag: 'select',
+          ariaLabel: 'Filter 2',
+          text: '',
+          xPath: '//*[@id="filter-two"]',
+          cssSelector: '#filter-two',
+          label: 'Filter 2',
+          value: '',
+        },
+      ],
+    };
+
+    const relatedPageDef = buildPageDefinition(overlaySnapshot, 'revance_oce_fulldev', {
+      '001ABCDEF123456': 'account_id',
+    });
+
+    const toolDef = buildToolDefinition([
+      {
+        ...createClickAction(relatedCasesUrl, {
+          tag: 'button',
+          ariaLabel: 'Show quick filters',
+          selectors: { css: '#quick-filters', aria: { role: 'button', name: 'Show quick filters' } },
+        }),
+        timestamp: 1100,
+      },
+      {
+        ...createClickAction(relatedCasesUrl, {
+          tag: 'button',
+          ariaLabel: 'Show Status column actions',
+          selectors: { css: '#status-actions', aria: { role: 'button', name: 'Show Status column actions' } },
+        }),
+        timestamp: 1500,
+      },
+      {
+        ...createClickAction(relatedCasesUrl, {
+          tag: 'button',
+          ariaLabel: 'New',
+          text: 'New',
+          selectors: { css: '#new-status', aria: { role: 'button', name: 'New' } },
+        }),
+        timestamp: 2100,
+      },
+    ], {
+      [`${relatedCasesUrl}#base`]: baseSnapshot,
+      [`${relatedCasesUrl}#overlay`]: overlaySnapshot,
+    }, {
+      name: 'salesforce_account_case_filter',
+      description: 'Filter related cases by status',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          account_id: { type: 'string', description: 'Account ID' },
+        },
+        required: ['account_id'],
+      },
+      templateVariables: {
+        '001ABCDEF123456': 'account_id',
+      },
+    }, [relatedPageDef]);
+
+    expect(toolDef.tool.bridge.steps).toEqual([
+      {
+        navigate: {
+          page: 'account_related_cases_view',
+          params: { account_id: '{{account_id}}' },
+        },
+      },
+      { wait: 2000 },
+      {
+        interact: {
+          field: 'account_related_cases_view.fields.show_quick_filters',
+          action: 'click',
+        },
+      },
+      { wait: 1000 },
+      {
+        interact: {
+          field: 'account_related_cases_view.fields.filter_1',
+          action: 'select',
+          value: 'Status',
+        },
+      },
+      { wait: 500 },
+      {
+        interact: {
+          field: 'account_related_cases_view.fields.filter_2',
+          action: 'select',
+          value: 'New',
+        },
+      },
+    ]);
+  });
+});

--- a/packages/extension/src/panel/builders/yaml-builder.ts
+++ b/packages/extension/src/panel/builders/yaml-builder.ts
@@ -781,8 +781,7 @@ export function buildToolDefinition(
     const pageDef = pageDefinitions.find(def => def.page.id === pageId) || null;
     const filterIntent = isFilterIntent(meta);
     const quickFilterSupported = supportsQuickFilters(pageDef);
-
-    function getResolvedField(): { fieldRef: string; field: ResolvedFieldMatch } | null {
+    const getResolvedField = (): { fieldRef: string; field: ResolvedFieldMatch } | null => {
       const field = resolveFieldForAction(action, snapshot, pageDef);
       if (!field) {
         return null;
@@ -791,7 +790,7 @@ export function buildToolDefinition(
         fieldRef: `${currentPageId || pageId || 'page'}.fields.${field.id}`,
         field,
       };
-    }
+    };
 
     // Emit step for EVERY recorded action
     switch (action.type) {
@@ -884,7 +883,6 @@ export function buildToolDefinition(
       }
 
       case 'keypress': {
-        const key = action.metadata?.key as string || 'unknown';
         // Add as a comment-like wait step (keypress not directly supported in schema)
         steps.push({ wait: 500 });
         break;

--- a/packages/extension/src/panel/builders/yaml-builder.ts
+++ b/packages/extension/src/panel/builders/yaml-builder.ts
@@ -1,0 +1,1247 @@
+/**
+ * Deterministic YAML builder — converts recorded actions + captured page snapshots
+ * into valid semantic definitions WITHOUT AI-generated selectors.
+ *
+ * Selectors come from the actual page scan (CaptureSnapshot).
+ * AI only provides: tool name, description, template variable names.
+ */
+
+import type { CaptureSnapshot, CapturedElement } from '../reducer.js';
+import type { RecordedAction } from '../../content-script/recorder.js';
+
+// ─── Types ──────────────────────────────────────────────
+
+export interface ToolMetadata {
+  name: string;
+  description: string;
+  inputSchema: {
+    type: string;
+    properties: Record<string, { type: string; description: string }>;
+    required: string[];
+  };
+  /** Maps URL path segments to parameter names, e.g. { "001abc": "account_id" } */
+  templateVariables: Record<string, string>;
+}
+
+interface PageField {
+  id: string;
+  label: string;
+  type: string;
+  selectors: Array<Record<string, unknown>>;
+  interaction: { type: string; value?: string };
+}
+
+interface PageOutput {
+  id: string;
+  label: string;
+  selectors: Array<Record<string, unknown>>;
+  capture_strategies?: Array<Record<string, unknown>>;
+}
+
+export interface PageDefinition {
+  page: {
+    id: string;
+    app: string;
+    url_pattern: string;
+    url_template: string;
+    wait_for: string;
+    fields: PageField[];
+    outputs: PageOutput[];
+  };
+}
+
+export interface AppDefinition {
+  app: {
+    id: string;
+    name: string;
+    base_url: string;
+    url_patterns: string[];
+  };
+}
+
+export interface ToolDefinition {
+  tool: {
+    name: string;
+    description: string;
+    inputSchema: Record<string, unknown>;
+    bridge: {
+      page: string;
+      steps: Array<Record<string, unknown>>;
+      returns: Record<string, string>;
+    };
+  };
+}
+
+// ─── Helpers ────────────────────────────────────────────
+
+function toSnakeCase(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_|_$/g, '');
+}
+
+function normalizeText(str: string | undefined): string {
+  return (str || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+function tokenize(str: string | undefined): string[] {
+  const normalized = normalizeText(str);
+  return normalized ? normalized.split(/\s+/) : [];
+}
+
+function titleCase(str: string): string {
+  return str
+    .split('_')
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function createUniqueId(raw: string, usedIds: Set<string>, fallback: string): string {
+  const base = toSnakeCase(raw) || fallback;
+  let candidate = base;
+  let suffix = 2;
+
+  while (usedIds.has(candidate)) {
+    candidate = `${base}_${suffix++}`;
+  }
+
+  usedIds.add(candidate);
+  return candidate;
+}
+
+function isSpecificCssSelector(selector: string | undefined): boolean {
+  if (!selector) return false;
+
+  return selector.startsWith('#') ||
+    selector.startsWith('[') ||
+    selector.includes('.') ||
+    selector.includes(':') ||
+    selector.includes(' ') ||
+    selector.includes('>');
+}
+
+function buildLabelRelativeJs(label: string): string {
+  const escapedLabel = label.replace(/'/g, "\\'");
+  return `(() => { const labels = document.querySelectorAll('.slds-form-element__label, .test-id__field-label'); for (const l of labels) { if (l.textContent.trim() === '${escapedLabel}') { const fe = l.closest('.slds-form-element'); if (fe) { const a = fe.querySelector('a'); if (a) return a; const input = fe.querySelector('input, select, textarea, button'); if (input) return input; const val = fe.querySelector('.slds-form-element__control, .test-id__field-value'); if (val) return val; } } } return null; })()`;
+}
+
+/**
+ * Build selector chain for a captured element.
+ * Uses the actual selectors from the page scan — never invents.
+ */
+function buildSelectors(el: CapturedElement): Array<Record<string, unknown>> {
+  const selectors: Array<Record<string, unknown>> = [];
+
+  // 1. ARIA strategy
+  if (el.ariaLabel || el.label) {
+    const name = el.ariaLabel || el.label;
+    let role = 'textbox';
+    if (el.type === 'checkbox') role = 'checkbox';
+    else if (el.type === 'radio') role = 'radio';
+    else if (el.tag === 'select') role = 'combobox';
+    else if (el.tag === 'button') role = 'button';
+    else if (el.tag === 'a') role = 'link';
+    else if (el.type === 'search') role = 'searchbox';
+    else if (el.type === 'tab' || el.ariaLabel?.toLowerCase().includes('tab')) role = 'tab';
+    selectors.push({ strategy: 'aria', role, name, confidence: 0.95 });
+  }
+
+  // 2. Text strategy (for buttons and links with visible text)
+  if (el.text && (el.tag === 'button' || el.tag === 'a') && !el.text.includes('\n')) {
+    const textVal = el.text.substring(0, 60).trim();
+    if (textVal.length > 0 && textVal.length < 60) {
+      selectors.push({ strategy: 'text', text: textVal, exact: true, confidence: 0.85 });
+    }
+  }
+
+  // 3. CSS strategy (from actual page scan)
+  if (el.cssSelector && (isSpecificCssSelector(el.cssSelector) || selectors.length === 0)) {
+    selectors.push({ strategy: 'css', selector: el.cssSelector, confidence: 0.80 });
+  }
+
+  // 4. Shadow DOM JS strategy
+  if (el.shadowPath) {
+    selectors.push({
+      strategy: 'js',
+      expression: `(() => { const el = document.querySelector('${el.shadowPath.replace(/'/g, "\\'")}'); return el; })()`,
+      confidence: 0.75,
+    });
+  }
+
+  // 5. Label-relative JS strategy for field_value types (Salesforce fields)
+  if (el.type === 'field_value' && el.label) {
+    selectors.push({ strategy: 'js', expression: buildLabelRelativeJs(el.label), confidence: 0.85 });
+  }
+
+  // Interactive Salesforce fields often only expose weak selectors like plain "a" or "button".
+  if (el.label && (el.tag === 'a' || el.tag === 'button') && !isSpecificCssSelector(el.cssSelector)) {
+    selectors.push({ strategy: 'js', expression: buildLabelRelativeJs(el.label), confidence: 0.82 });
+  }
+
+  // Ensure at least one selector
+  if (selectors.length === 0 && el.id) {
+    selectors.push({ strategy: 'css', selector: `#${el.id}`, confidence: 0.70 });
+  }
+
+  return selectors;
+}
+
+function mapFieldType(el: CapturedElement): string {
+  if (el.tag === 'select') return 'picklist';
+  if (el.type === 'checkbox') return 'checkbox';
+  if (el.type === 'radio') return 'radio';
+  if (el.tag === 'button' || el.tag === 'a') return 'action_button';
+  if (el.tag === 'textarea') return 'textarea';
+  return 'text';
+}
+
+function mapInteraction(el: CapturedElement): { type: string } {
+  if (el.tag === 'button' || el.tag === 'a') return { type: 'click' };
+  if (el.tag === 'select') return { type: 'select' };
+  if (el.type === 'checkbox') return { type: 'check' };
+  return { type: 'fill' };
+}
+
+function isSalesforceId(segment: string): boolean {
+  return /^[a-zA-Z0-9]{15,18}$/.test(segment);
+}
+
+export function deriveTemplateVariables(pages: string[]): Record<string, string> {
+  const templateVars: Record<string, string> = {};
+
+  for (const url of pages) {
+    try {
+      const parts = new URL(url).pathname.split('/').filter(Boolean);
+      const rIdx = parts.indexOf('r');
+      if (rIdx >= 0 && parts[rIdx + 1] && parts[rIdx + 2]) {
+        const objectName = parts[rIdx + 1]!;
+        const objectId = parts[rIdx + 2]!;
+        if (isSalesforceId(objectId)) {
+          const paramName = `${toSnakeCase(objectName)}_id`;
+          if (paramName && !templateVars[objectId]) {
+            templateVars[objectId] = paramName;
+          }
+        }
+      }
+    } catch {
+      // Ignore malformed URLs in partial recordings.
+    }
+  }
+
+  return templateVars;
+}
+
+// Extract URL pattern by replacing IDs with wildcards.
+// e.g. /lightning/r/Account/001abc/view -> /lightning/r/Account/{wildcard}/view
+function urlToPattern(url: string): string {
+  try {
+    const u = new URL(url);
+    // Replace Salesforce 15/18-char IDs with *
+    return u.pathname.replace(/\/[a-zA-Z0-9]{15,18}(?=\/|$)/g, '/*');
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Build URL template from URL + template variables.
+ * e.g. /lightning/r/Account/001abc/view with { "001abc": "account_id" }
+ *   -> {{app.base_url}}/lightning/r/Account/{{account_id}}/view
+ */
+function urlToTemplate(url: string, templateVars: Record<string, string>): string {
+  try {
+    const u = new URL(url);
+    let path = u.pathname;
+    for (const [literal, paramName] of Object.entries(templateVars)) {
+      path = path.replace(literal, `{{${paramName}}}`);
+    }
+    return `{{app.base_url}}${path}`;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Derive a page ID from URL path.
+ * e.g. /lightning/r/Account/001abc/view -> account_view
+ */
+function urlToPageId(url: string): string {
+  try {
+    const u = new URL(url);
+    const parts = u.pathname.split('/').filter(Boolean);
+    // For Salesforce: /lightning/r/ObjectName/ID/view -> objectname_view
+    // But /lightning/r/ObjectName/ID/related/Cases/view -> objectname_related_cases_view
+    const objectIdx = parts.indexOf('r');
+    if (objectIdx >= 0 && parts[objectIdx + 1]) {
+      const obj = parts[objectIdx + 1]!.toLowerCase();
+      // Collect all meaningful path segments after the ID
+      const afterObj = parts.slice(objectIdx + 2);
+      const meaningful = afterObj.filter(p => !isSalesforceId(p));
+      if (meaningful.length > 0) {
+        return `${obj}_${meaningful.map(s => s.toLowerCase()).join('_')}`;
+      }
+      return `${obj}_detail`;
+    }
+    // For /lightning/n/ObjectName -> objectname
+    const nIdx = parts.indexOf('n');
+    if (nIdx >= 0 && parts[nIdx + 1]) {
+      return toSnakeCase(parts[nIdx + 1]!) || 'page';
+    }
+    // Fallback: last meaningful path segment
+    const meaningful = parts.filter(p => !isSalesforceId(p));
+    return toSnakeCase(meaningful.slice(-2).join('_')) || 'page';
+  } catch {
+    return 'page';
+  }
+}
+
+// ─── Match recorded action to captured element ──────────
+
+/**
+ * Find the best matching CapturedElement for a recorded action.
+ * Matches by score across CSS selector, label/nearbyLabel, aria, text, and id.
+ */
+function matchActionToElement(
+  action: RecordedAction,
+  snapshot: CaptureSnapshot,
+): CapturedElement | null {
+  const el = action.element;
+  if (!el) return null;
+
+  let bestMatch: CapturedElement | null = null;
+  let bestScore = 0;
+
+  for (const candidate of snapshot.elements) {
+    let score = 0;
+
+    if (el.selectors?.css && candidate.cssSelector && el.selectors.css === candidate.cssSelector) {
+      score += 200;
+    }
+
+    if (el.id && candidate.id && el.id === candidate.id) {
+      score += 180;
+    }
+
+    const actionAria = normalizeText((el.selectors?.aria as { name?: string } | undefined)?.name || el.ariaLabel);
+    const candidateAria = normalizeText(candidate.ariaLabel || candidate.label);
+    if (actionAria && candidateAria) {
+      if (actionAria === candidateAria) score += 140;
+      else if (candidateAria.includes(actionAria) || actionAria.includes(candidateAria)) score += 90;
+    }
+
+    const actionLabels = [el.nearbyLabel, el.ariaLabel, el.text];
+    const candidateLabels = [candidate.label, candidate.ariaLabel, candidate.text];
+    for (const actionLabel of actionLabels) {
+      const normalizedAction = normalizeText(actionLabel);
+      if (!normalizedAction) continue;
+      for (const candidateLabel of candidateLabels) {
+        const normalizedCandidate = normalizeText(candidateLabel);
+        if (!normalizedCandidate) continue;
+        if (normalizedAction === normalizedCandidate) score += 120;
+        else if (normalizedCandidate.includes(normalizedAction) || normalizedAction.includes(normalizedCandidate)) score += 70;
+      }
+    }
+
+    if (score > bestScore) {
+      bestScore = score;
+      bestMatch = candidate;
+    }
+  }
+
+  return bestScore >= 70 ? bestMatch : null;
+}
+
+interface IndexedPageField {
+  id: string;
+  label: string;
+  type: string;
+  interactionType: string;
+  selectors: Array<Record<string, unknown>>;
+}
+
+interface ResolvedFieldMatch {
+  id: string;
+  label: string;
+  type: string;
+  interactionType: string;
+}
+
+interface QuickFilterState {
+  active: boolean;
+  nextFilterIndex: number;
+  selectedValues: string[];
+}
+
+function collectActionHints(
+  action: RecordedAction,
+  matchedElement: CapturedElement | null,
+): string[] {
+  const hints = [
+    action.element?.nearbyLabel,
+    action.element?.ariaLabel,
+    (action.element?.selectors?.aria as { name?: string } | undefined)?.name,
+    action.element?.text,
+    action.element?.id,
+    matchedElement?.label,
+    matchedElement?.ariaLabel,
+    matchedElement?.text,
+    matchedElement?.id,
+  ]
+    .map(value => normalizeText(value))
+    .filter(Boolean);
+
+  return Array.from(new Set(hints));
+}
+
+function findFieldByExactSelector(
+  fields: IndexedPageField[],
+  action: RecordedAction,
+  matchedElement: CapturedElement | null,
+): string | null {
+  const actionCss = action.element?.selectors?.css;
+  const actionAria = action.element?.selectors?.aria as { role?: string; name?: string } | undefined;
+  const matchedCss = matchedElement?.cssSelector;
+  const matchedAria = matchedElement?.ariaLabel;
+
+  for (const field of fields) {
+    for (const selector of field.selectors) {
+      if (selector.strategy === 'css' && typeof selector.selector === 'string') {
+        if (!isSpecificCssSelector(selector.selector)) {
+          continue;
+        }
+        if ((actionCss && selector.selector === actionCss) || (matchedCss && selector.selector === matchedCss)) {
+          return field.id;
+        }
+      }
+
+      if (selector.strategy === 'aria' && typeof selector.name === 'string') {
+        const selectorName = normalizeText(selector.name);
+        const selectorRole = typeof selector.role === 'string' ? selector.role : undefined;
+        const actionName = normalizeText(actionAria?.name || action.element?.ariaLabel);
+        const matchedName = normalizeText(matchedAria);
+
+        if (selectorRole && actionAria?.role && selectorRole !== actionAria.role) {
+          continue;
+        }
+
+        if ((actionName && selectorName === actionName) || (matchedName && selectorName === matchedName)) {
+          return field.id;
+        }
+      }
+
+      if (selector.strategy === 'text' && typeof selector.text === 'string') {
+        const selectorText = normalizeText(selector.text);
+        const actionText = normalizeText(action.element?.text);
+        const matchedText = normalizeText(matchedElement?.text);
+        if ((actionText && selectorText === actionText) || (matchedText && selectorText === matchedText)) {
+          return field.id;
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+function scoreFieldMatch(field: IndexedPageField, hints: string[], action: RecordedAction): number {
+  const normalizedLabel = normalizeText(field.label);
+  const normalizedId = normalizeText(field.id);
+  const labelTokens = new Set(tokenize(field.label));
+  let score = 0;
+
+  for (const hint of hints) {
+    if (!hint) continue;
+
+    if (hint === normalizedLabel || hint === normalizedId) {
+      score += 120;
+      continue;
+    }
+
+    if (normalizedLabel.includes(hint) || hint.includes(normalizedLabel) ||
+        normalizedId.includes(hint) || hint.includes(normalizedId)) {
+      score += 75;
+    }
+
+    const hintTokens = tokenize(hint);
+    if (hintTokens.length > 0) {
+      const overlap = hintTokens.filter(token => labelTokens.has(token));
+      if (overlap.length > 0) {
+        score += overlap.length * 20;
+        if (overlap.length === hintTokens.length) {
+          score += 30;
+        }
+      }
+    }
+  }
+
+  if ((action.element?.tag === 'button' || action.element?.tag === 'a') && field.type === 'action_button') {
+    score += 10;
+  }
+
+  if (action.type === 'input') {
+    if (field.interactionType === 'select' || field.interactionType === 'fill') {
+      score += 25;
+    }
+    if (field.type === 'action_button') {
+      score -= 80;
+    }
+  }
+
+  if (action.type === 'click' && field.type === 'picklist') {
+    score -= 10;
+  }
+
+  return score;
+}
+
+function resolveFieldForAction(
+  action: RecordedAction,
+  snapshot: CaptureSnapshot | null,
+  pageDef: PageDefinition | null,
+): ResolvedFieldMatch | null {
+  if (!pageDef) return null;
+
+  const indexedFields: IndexedPageField[] = pageDef.page.fields.map(field => ({
+    id: field.id,
+    label: field.label,
+    type: field.type,
+    interactionType: field.interaction.type,
+    selectors: field.selectors,
+  }));
+
+  const matchedElement = snapshot ? matchActionToElement(action, snapshot) : null;
+  const exactSelectorMatch = findFieldByExactSelector(indexedFields, action, matchedElement);
+  if (exactSelectorMatch) {
+    const field = indexedFields.find(candidate => candidate.id === exactSelectorMatch)!;
+    return {
+      id: field.id,
+      label: field.label,
+      type: field.type,
+      interactionType: field.interactionType,
+    };
+  }
+
+  const hints = collectActionHints(action, matchedElement);
+  let bestField: IndexedPageField | null = null;
+  let bestScore = 0;
+
+  for (const field of indexedFields) {
+    const score = scoreFieldMatch(field, hints, action);
+    if (score > bestScore) {
+      bestScore = score;
+      bestField = field;
+    }
+  }
+
+  if (bestScore < 60 || !bestField) {
+    return null;
+  }
+
+  return {
+    id: bestField.id,
+    label: bestField.label,
+    type: bestField.type,
+    interactionType: bestField.interactionType,
+  };
+}
+
+function isFilterIntent(meta: ToolMetadata): boolean {
+  const text = `${meta.name} ${meta.description}`.toLowerCase();
+  return text.includes('filter') || text.includes('status');
+}
+
+function getFieldIdFromRef(fieldRef: string | undefined): string {
+  if (!fieldRef) return '';
+  const parts = fieldRef.split('.fields.');
+  return parts[1] || '';
+}
+
+function hasField(pageDef: PageDefinition | null, fieldId: string): boolean {
+  return !!pageDef?.page.fields.some(field => field.id === fieldId);
+}
+
+function supportsQuickFilters(pageDef: PageDefinition | null): boolean {
+  return hasField(pageDef, 'show_quick_filters') && hasField(pageDef, 'filter_1');
+}
+
+function isQuickFilterNoiseFieldId(fieldId: string): boolean {
+  return fieldId === 'merge_cases' ||
+    fieldId === 'list_view_controls' ||
+    fieldId === 'column_sort' ||
+    fieldId.endsWith('_column_width') ||
+    /^show_.+_column_actions$/.test(fieldId) ||
+    /^sort_by_/.test(fieldId);
+}
+
+function formatSelectionToken(raw: string): string {
+  const normalized = raw.replace(/[_-]+/g, ' ').trim();
+  if (!normalized) return '';
+  return normalized
+    .split(/\s+/)
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function extractQuickFilterValueCandidate(
+  action: RecordedAction,
+  resolved: ResolvedFieldMatch | null,
+  slotIndex: number,
+): string | null {
+  const inputValue = (action.metadata?.inputValue as string | undefined)?.trim();
+  if (inputValue) {
+    return inputValue;
+  }
+
+  if (!resolved) {
+    return null;
+  }
+
+  if (slotIndex === 1) {
+    const showColumnMatch = resolved.id.match(/^show_(.+)_column_actions$/);
+    if (showColumnMatch?.[1]) {
+      return formatSelectionToken(showColumnMatch[1]);
+    }
+
+    const sortMatch = resolved.id.match(/^sort_by_(.+)$/);
+    if (sortMatch?.[1]) {
+      return formatSelectionToken(sortMatch[1]);
+    }
+  }
+
+  if (slotIndex >= 2) {
+    if (isQuickFilterNoiseFieldId(resolved.id) || resolved.id === 'show_quick_filters') {
+      return null;
+    }
+
+    const candidate = action.element?.text || action.element?.ariaLabel || resolved.label;
+    const normalized = normalizeText(candidate);
+    if (!normalized || normalized.includes('show ') || normalized.includes('sort by') || normalized.includes('column')) {
+      return null;
+    }
+
+    if (candidate && candidate.trim().length <= 32) {
+      return candidate.trim();
+    }
+  }
+
+  return null;
+}
+
+export function buildAppDefinition(appId: string, pages: string[]): AppDefinition {
+  let baseUrl = '';
+  const urlPatterns = new Set<string>();
+
+  for (const url of pages) {
+    try {
+      const parsed = new URL(url);
+      if (!baseUrl) {
+        baseUrl = parsed.origin;
+      }
+      urlPatterns.add(urlToPattern(url));
+    } catch {
+      // Ignore invalid URLs in partially recorded sessions.
+    }
+  }
+
+  return {
+    app: {
+      id: appId,
+      name: titleCase(appId),
+      base_url: baseUrl,
+      url_patterns: Array.from(urlPatterns),
+    },
+  };
+}
+
+// ─── Build Page Definition ──────────────────────────────
+
+export function buildPageDefinition(
+  snapshot: CaptureSnapshot,
+  appId: string,
+  templateVars: Record<string, string>,
+): PageDefinition {
+  const pageId = urlToPageId(snapshot.url);
+  const urlPattern = urlToPattern(snapshot.url);
+  const urlTemplate = urlToTemplate(snapshot.url, templateVars);
+
+  const fields: PageField[] = [];
+  const outputs: PageOutput[] = [];
+  const usedIds = new Set<string>();
+
+  for (const el of snapshot.elements) {
+    const fallbackId = `el_${fields.length + outputs.length + 1}`;
+    const fieldId = createUniqueId(
+      el.label || el.text || el.id || fallbackId,
+      usedIds,
+      fallbackId,
+    );
+    const selectors = buildSelectors(el);
+    if (selectors.length === 0) continue;
+
+    if (el.type === 'field_value') {
+      // This is a read-only field value (from Salesforce .slds-form-element)
+      outputs.push({
+        id: fieldId,
+        label: el.label || el.text || fieldId,
+        selectors,
+        ...(el.href ? {
+          capture_strategies: [{
+            type: 'attribute',
+            attribute: 'href',
+            selectors,
+          }],
+        } : {
+          capture_strategies: [{
+            type: 'text_content',
+            selectors,
+          }],
+        }),
+      });
+    } else if (el.tag === 'button' || el.tag === 'a' || el.tag === 'input' || el.tag === 'select' || el.tag === 'textarea') {
+      fields.push({
+        id: fieldId,
+        label: el.label || el.text || fieldId,
+        type: mapFieldType(el),
+        selectors,
+        interaction: mapInteraction(el),
+      });
+    }
+  }
+
+  return {
+    page: {
+      id: pageId,
+      app: appId,
+      url_pattern: urlPattern,
+      url_template: urlTemplate,
+      wait_for: '.slds-page-header',
+      fields,
+      outputs,
+    },
+  };
+}
+
+// ─── Build Tool Definition ──────────────────────────────
+
+export function buildToolDefinition(
+  actions: RecordedAction[],
+  pageSnapshots: Record<string, CaptureSnapshot>,
+  meta: ToolMetadata,
+  pageDefinitions: PageDefinition[] = [],
+): ToolDefinition {
+  const steps: Array<Record<string, unknown>> = [];
+  const returns: Record<string, string> = {};
+  let currentPageId = '';
+  let lastUrl = '';
+  const quickFilterState: QuickFilterState = {
+    active: false,
+    nextFilterIndex: 1,
+    selectedValues: [],
+  };
+
+  for (let idx = 0; idx < actions.length; idx++) {
+    const action = actions[idx]!;
+    const actionUrl = action.url || (action.metadata?.toUrl as string) || '';
+
+    // Find the matching snapshot for this action's URL
+    const snapshot = findSnapshotForUrl(actionUrl, pageSnapshots, action.timestamp);
+    const pageId = snapshot ? urlToPageId(snapshot.url) : currentPageId;
+
+    // Detect page change — emit navigate step
+    if (actionUrl && actionUrl !== lastUrl && pageId && pageId !== currentPageId) {
+      const navigateStep: Record<string, unknown> = {
+        navigate: { page: pageId },
+      };
+
+      const params: Record<string, string> = {};
+      for (const [literal, paramName] of Object.entries(meta.templateVariables)) {
+        if (actionUrl.includes(literal)) {
+          params[paramName] = `{{${paramName}}}`;
+        }
+      }
+      if (Object.keys(params).length > 0) {
+        (navigateStep.navigate as Record<string, unknown>).params = params;
+      }
+
+      steps.push(navigateStep);
+      steps.push({ wait: 2000 });
+      currentPageId = pageId;
+      lastUrl = actionUrl;
+    } else if (actionUrl && actionUrl !== lastUrl) {
+      lastUrl = actionUrl;
+    }
+
+    // Build a field reference for this action
+    const pageDef = pageDefinitions.find(def => def.page.id === pageId) || null;
+    const filterIntent = isFilterIntent(meta);
+    const quickFilterSupported = supportsQuickFilters(pageDef);
+
+    function getResolvedField(): { fieldRef: string; field: ResolvedFieldMatch } | null {
+      const field = resolveFieldForAction(action, snapshot, pageDef);
+      if (!field) {
+        return null;
+      }
+      return {
+        fieldRef: `${currentPageId || pageId || 'page'}.fields.${field.id}`,
+        field,
+      };
+    }
+
+    // Emit step for EVERY recorded action
+    switch (action.type) {
+      case 'click': {
+        const resolved = getResolvedField();
+        if (resolved) {
+          if (filterIntent && quickFilterSupported && resolved.field.id === 'show_quick_filters') {
+            quickFilterState.active = true;
+          } else if (filterIntent && quickFilterSupported && quickFilterState.active) {
+            const selectionValue = extractQuickFilterValueCandidate(
+              action,
+              resolved.field,
+              quickFilterState.nextFilterIndex,
+            );
+
+            if (selectionValue && hasField(pageDef, `filter_${quickFilterState.nextFilterIndex}`)) {
+              if (!quickFilterState.selectedValues.includes(selectionValue)) {
+                steps.push({
+                  interact: {
+                    field: `${currentPageId || pageId || 'page'}.fields.filter_${quickFilterState.nextFilterIndex}`,
+                    action: 'select',
+                    value: selectionValue,
+                  },
+                });
+                steps.push({ wait: 500 });
+                quickFilterState.selectedValues.push(selectionValue);
+                quickFilterState.nextFilterIndex += 1;
+              }
+              break;
+            }
+
+            if (isQuickFilterNoiseFieldId(resolved.field.id)) {
+              break;
+            }
+          }
+
+          steps.push({
+            interact: { field: resolved.fieldRef, action: 'click' },
+          });
+          steps.push({ wait: 1000 });
+        }
+        break;
+      }
+
+      case 'input': {
+        const inputVal = action.metadata?.inputValue as string || '';
+        let value = inputVal;
+        for (const [literal, paramName] of Object.entries(meta.templateVariables)) {
+          if (inputVal.includes(literal)) {
+            value = `{{${paramName}}}`;
+          }
+        }
+
+        if (filterIntent && quickFilterSupported && quickFilterState.active) {
+          if (!value.trim()) {
+            break;
+          }
+
+          if (hasField(pageDef, `filter_${quickFilterState.nextFilterIndex}`)) {
+            if (!quickFilterState.selectedValues.includes(value)) {
+              steps.push({
+                interact: {
+                  field: `${currentPageId || pageId || 'page'}.fields.filter_${quickFilterState.nextFilterIndex}`,
+                  action: 'select',
+                  value,
+                },
+              });
+              steps.push({ wait: 500 });
+              quickFilterState.selectedValues.push(value);
+              quickFilterState.nextFilterIndex += 1;
+            }
+            break;
+          }
+        }
+
+        const resolved = getResolvedField();
+        if (resolved) {
+          const actionType = resolved.field.interactionType === 'select'
+            ? 'select'
+            : resolved.field.interactionType === 'check'
+              ? 'check'
+              : 'fill';
+
+          steps.push({
+            interact: { field: resolved.fieldRef, action: actionType, value },
+          });
+          steps.push({ wait: 500 });
+        }
+        break;
+      }
+
+      case 'keypress': {
+        const key = action.metadata?.key as string || 'unknown';
+        // Add as a comment-like wait step (keypress not directly supported in schema)
+        steps.push({ wait: 500 });
+        break;
+      }
+
+      case 'navigate': {
+        // Already handled above via URL change detection
+        // But ensure we don't silently skip — if no navigate was emitted, add one
+        if (action.metadata?.toUrl) {
+          const toUrl = action.metadata.toUrl as string;
+          const navPageId = urlToPageId(toUrl);
+          if (navPageId !== currentPageId) {
+            const navStep: Record<string, unknown> = { navigate: { page: navPageId } };
+            const params: Record<string, string> = {};
+            for (const [literal, paramName] of Object.entries(meta.templateVariables)) {
+              if (toUrl.includes(literal)) {
+                params[paramName] = `{{${paramName}}}`;
+              }
+            }
+            if (Object.keys(params).length > 0) {
+              (navStep.navigate as Record<string, unknown>).params = params;
+            }
+            steps.push(navStep);
+            steps.push({ wait: 2000 });
+            currentPageId = navPageId;
+            lastUrl = toUrl;
+          }
+        }
+        break;
+      }
+
+      default:
+        // tab_switch or unknown — still emit a wait so nothing is silently dropped
+        steps.push({ wait: 500 });
+        break;
+    }
+  }
+
+  const optimizedSteps = optimizeToolSteps(steps, meta);
+
+  // Add returns from template variables
+  for (const paramName of Object.values(meta.templateVariables)) {
+    returns[paramName] = `{{${paramName}}}`;
+  }
+
+  return {
+    tool: {
+      name: meta.name,
+      description: meta.description,
+      inputSchema: meta.inputSchema,
+      bridge: {
+        page: currentPageId || 'unknown_page',
+        steps: optimizedSteps,
+        returns,
+      },
+    },
+  };
+}
+
+function hasNavigateParams(step: Record<string, unknown>): boolean {
+  const navigate = step.navigate as { params?: Record<string, string> } | undefined;
+  return !!navigate?.params && Object.keys(navigate.params).length > 0;
+}
+
+function isInteractStep(step: Record<string, unknown>): step is { interact: { field?: string; action?: string; value?: string } } {
+  return 'interact' in step;
+}
+
+function interactionKey(step: { interact: { field?: string; action?: string; value?: string } }): string {
+  return JSON.stringify([
+    step.interact.field ?? '',
+    step.interact.action ?? '',
+    step.interact.value ?? '',
+  ]);
+}
+
+function trimLeadingNavigationNoise(steps: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+  let startIdx = 0;
+
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i]!;
+    if (!('navigate' in step) || !hasNavigateParams(step)) {
+      continue;
+    }
+
+    const suffix = steps.slice(i + 1);
+    const hasLaterInteract = suffix.some(candidate => isInteractStep(candidate));
+    if (!hasLaterInteract) {
+      continue;
+    }
+
+    const prefix = steps.slice(0, i);
+    const prefixIsOnlyNavigationNoise = prefix.every(candidate => {
+      if ('wait' in candidate || 'navigate' in candidate) return true;
+      if (isInteractStep(candidate)) {
+        return (candidate.interact.action ?? 'click') === 'click';
+      }
+      return false;
+    });
+
+    if (prefixIsOnlyNavigationNoise) {
+      startIdx = i;
+    }
+  }
+
+  return steps.slice(startIdx);
+}
+
+function compactSteps(steps: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+  const compacted: Array<Record<string, unknown>> = [];
+
+  for (const step of steps) {
+    const previous = compacted[compacted.length - 1];
+
+    if ('wait' in step) {
+      if (!previous) {
+        continue;
+      }
+      if ('wait' in previous && typeof previous.wait === 'number' && typeof step.wait === 'number') {
+        previous.wait = Math.max(previous.wait, step.wait);
+        continue;
+      }
+      compacted.push(step);
+      continue;
+    }
+
+    if (isInteractStep(step)) {
+      let previousSignificantIndex = compacted.length - 1;
+      while (previousSignificantIndex >= 0 && 'wait' in compacted[previousSignificantIndex]!) {
+        previousSignificantIndex--;
+      }
+
+      const previousSignificant = previousSignificantIndex >= 0 ? compacted[previousSignificantIndex]! : null;
+      if (previousSignificant && isInteractStep(previousSignificant) && interactionKey(previousSignificant) === interactionKey(step)) {
+        continue;
+      }
+    }
+
+    compacted.push(step);
+  }
+
+  while (compacted.length > 0 && 'wait' in compacted[compacted.length - 1]!) {
+    compacted.pop();
+  }
+
+  return compacted;
+}
+
+function dropPreparatoryClicksBeforeValueChange(steps: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+  const optimized: Array<Record<string, unknown>> = [];
+
+  for (const step of steps) {
+    if (isInteractStep(step) && ['select', 'fill', 'check'].includes(step.interact.action ?? '')) {
+      let previousSignificantIndex = optimized.length - 1;
+      while (previousSignificantIndex >= 0 && 'wait' in optimized[previousSignificantIndex]!) {
+        previousSignificantIndex--;
+      }
+
+      const previousSignificant = previousSignificantIndex >= 0 ? optimized[previousSignificantIndex]! : null;
+      if (
+        previousSignificant &&
+        isInteractStep(previousSignificant) &&
+        previousSignificant.interact.action === 'click' &&
+        previousSignificant.interact.field === step.interact.field
+      ) {
+        optimized.splice(previousSignificantIndex);
+      }
+    }
+
+    optimized.push(step);
+  }
+
+  return optimized;
+}
+
+function dropQuickFilterNoise(
+  steps: Array<Record<string, unknown>>,
+  meta: ToolMetadata,
+): Array<Record<string, unknown>> {
+  if (!isFilterIntent(meta)) {
+    return steps;
+  }
+
+  const hasQuickFilterTrigger = steps.some(step =>
+    isInteractStep(step) && getFieldIdFromRef(step.interact.field) === 'show_quick_filters',
+  );
+
+  if (!hasQuickFilterTrigger) {
+    return steps;
+  }
+
+  return steps.filter(step => {
+    if (!isInteractStep(step)) {
+      return true;
+    }
+
+    const fieldId = getFieldIdFromRef(step.interact.field);
+    if (!fieldId) {
+      return true;
+    }
+
+    if (fieldId === 'show_quick_filters' || fieldId === 'filter_1' || fieldId === 'filter_2') {
+      return true;
+    }
+
+    if (isQuickFilterNoiseFieldId(fieldId)) {
+      return false;
+    }
+
+    return true;
+  });
+}
+
+function optimizeToolSteps(steps: Array<Record<string, unknown>>, meta: ToolMetadata): Array<Record<string, unknown>> {
+  return compactSteps(
+    dropPreparatoryClicksBeforeValueChange(
+      dropQuickFilterNoise(
+        trimLeadingNavigationNoise(steps),
+        meta,
+      ),
+    ),
+  );
+}
+
+// ─── Helpers ────────────────────────────────────────────
+
+function findSnapshotForUrl(
+  url: string,
+  snapshots: Record<string, CaptureSnapshot>,
+  actionTimestamp?: number,
+): CaptureSnapshot | null {
+  const entries = Object.values(snapshots);
+  if (entries.length === 0) {
+    return null;
+  }
+
+  // Try matching by exact URL first, then by pathname.
+  let candidates = entries.filter(snapshot => snapshot.url === url);
+
+  try {
+    if (candidates.length === 0) {
+      const targetPath = new URL(url).pathname;
+      candidates = entries.filter(snapshot => {
+        try {
+          return new URL(snapshot.url).pathname === targetPath;
+        } catch {
+          return false;
+        }
+      });
+    }
+  } catch {
+    // Invalid URL
+  }
+
+  if (candidates.length === 0) {
+    candidates = entries;
+  }
+
+  if (typeof actionTimestamp === 'number') {
+    return candidates
+      .slice()
+      .sort((a, b) => {
+        const aDistance = Math.abs(a.timestamp - actionTimestamp);
+        const bDistance = Math.abs(b.timestamp - actionTimestamp);
+        if (aDistance !== bDistance) {
+          return aDistance - bDistance;
+        }
+
+        const aIsAfter = a.timestamp >= actionTimestamp ? 0 : 1;
+        const bIsAfter = b.timestamp >= actionTimestamp ? 0 : 1;
+        if (aIsAfter !== bIsAfter) {
+          return aIsAfter - bIsAfter;
+        }
+
+        return a.timestamp - b.timestamp;
+      })[0] || null;
+  }
+
+  return candidates.sort((a, b) => a.timestamp - b.timestamp).at(-1) || null;
+}
+
+// ─── YAML Serializer ────────────────────────────────────
+
+function yamlScalar(val: unknown): string {
+  if (val === null || val === undefined) return 'null';
+  if (typeof val === 'number') return String(val);
+  if (typeof val === 'boolean') return String(val);
+  const s = String(val);
+  if (s === '') return '""';
+  // Quote if: contains special chars, template syntax, or looks like a number/bool
+  if (s.includes('{{') || s.includes('"') || s.includes("'") || s.includes('\n') ||
+      s.includes(': ') || s.includes('#') || s.startsWith('*') || s.startsWith('&') ||
+      s.startsWith('!') || s.startsWith('{') || s.startsWith('[') ||
+      /^[0-9]/.test(s) || s === 'true' || s === 'false' || s === 'null' ||
+      s === 'yes' || s === 'no' || s === 'on' || s === 'off') {
+    return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  }
+  if (/^[a-zA-Z_][a-zA-Z0-9_./ *-]*$/.test(s)) return s;
+  return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function yamlLines(obj: unknown, indent: number): string[] {
+  const pad = '  '.repeat(indent);
+
+  if (obj === null || obj === undefined || typeof obj === 'string' ||
+      typeof obj === 'number' || typeof obj === 'boolean') {
+    return [yamlScalar(obj)];
+  }
+
+  if (Array.isArray(obj)) {
+    if (obj.length === 0) return ['[]'];
+    const result: string[] = [];
+    for (const item of obj) {
+      if (typeof item === 'object' && item !== null && !Array.isArray(item)) {
+        // Object in array: first key on same line as -, rest indented under it
+        const entries = Object.entries(item as Record<string, unknown>);
+        for (let i = 0; i < entries.length; i++) {
+          const [key, val] = entries[i]!;
+          const prefix = i === 0 ? `${pad}- ` : `${pad}  `;
+          if (val === null || val === undefined || typeof val === 'string' ||
+              typeof val === 'number' || typeof val === 'boolean') {
+            result.push(`${prefix}${key}: ${yamlScalar(val)}`);
+          } else {
+            result.push(`${prefix}${key}:`);
+            for (const line of yamlLines(val, indent + 2)) {
+              result.push(line);
+            }
+          }
+        }
+      } else {
+        result.push(`${pad}- ${yamlScalar(item)}`);
+      }
+    }
+    return result;
+  }
+
+  if (typeof obj === 'object') {
+    const entries = Object.entries(obj as Record<string, unknown>);
+    if (entries.length === 0) return ['{}'];
+    const result: string[] = [];
+    for (const [key, val] of entries) {
+      if (val === null || val === undefined || typeof val === 'string' ||
+          typeof val === 'number' || typeof val === 'boolean') {
+        result.push(`${pad}${key}: ${yamlScalar(val)}`);
+      } else {
+        result.push(`${pad}${key}:`);
+        for (const line of yamlLines(val, indent + 1)) {
+          result.push(line);
+        }
+      }
+    }
+    return result;
+  }
+
+  return [yamlScalar(obj)];
+}
+
+export function toYamlString(obj: unknown): string {
+  return yamlLines(obj, 0).join('\n');
+}

--- a/packages/extension/src/panel/components/GuideMode.tsx
+++ b/packages/extension/src/panel/components/GuideMode.tsx
@@ -1,0 +1,747 @@
+/**
+ * Guide Mode — Record + Auto-Capture + Deterministic Build.
+ *
+ * Flow:
+ * 1. User hits Record → recorder captures clicks/navigation
+ * 2. On each page navigation, auto-runs page capture (same logic as CaptureMode)
+ * 3. User stops recording → clicks Build Tool
+ * 4. Builder matches recorded actions to captured elements (real selectors)
+ * 5. AI only provides: tool name, description, template variable names
+ * 6. YAML is built deterministically — no AI-generated selectors
+ */
+import React, { useRef, useEffect, useState, useCallback } from 'react';
+import type { SidePanelState, SidePanelAction, RecordedAction, CaptureSnapshot } from '../reducer.js';
+import { runCapture } from '../utils/run-capture.js';
+import {
+  buildAppDefinition,
+  buildPageDefinition,
+  buildToolDefinition,
+  deriveTemplateVariables,
+  toYamlString,
+  type ToolMetadata,
+} from '../builders/yaml-builder.js';
+
+const GUIDE_API_URL = 'http://localhost:3456/guide-build';
+
+interface Props {
+  state: SidePanelState;
+  dispatch: React.Dispatch<SidePanelAction>;
+}
+
+// ─── Action helpers ──────────────────────────────────────
+
+function getActionIcon(type: string): string {
+  switch (type) {
+    case 'click': return '\u{1F5B1}';
+    case 'input': return '\u2328';
+    case 'navigate': return '\u{1F517}';
+    case 'keypress': return '\u2328';
+    default: return '\u25CF';
+  }
+}
+
+function getActionLabel(action: RecordedAction): string {
+  const el = action.element;
+  switch (action.type) {
+    case 'click': {
+      const target = el?.nearbyLabel || el?.ariaLabel || el?.text?.substring(0, 40) || el?.tag || 'element';
+      return `Click "${target}"`;
+    }
+    case 'input': {
+      const field = el?.nearbyLabel || el?.ariaLabel || el?.placeholder || el?.tag || 'field';
+      const val = action.metadata?.inputValue;
+      if (action.metadata?.inputKind === 'select') {
+        return `Select "${(val as string | undefined)?.substring(0, 25) || 'option'}" in "${field}"`;
+      }
+      return `Type in "${field}"${val ? `: "${(val as string).substring(0, 25)}"` : ''}`;
+    }
+    case 'navigate': {
+      const to = action.metadata?.toUrl as string | undefined;
+      if (to) {
+        try { return `Navigate to ${new URL(to).pathname.substring(0, 50)}`; }
+        catch { return `Navigate to ${to.substring(0, 50)}`; }
+      }
+      return 'Page navigation';
+    }
+    case 'keypress':
+      return `Press ${(action.metadata?.key as string) || 'key'}`;
+    default:
+      return action.type;
+  }
+}
+
+function getElementDetail(action: RecordedAction): string | null {
+  const el = action.element;
+  if (!el) return null;
+  const parts: string[] = [];
+  parts.push(`<${el.tag}>`);
+  if (el.ariaRole) parts.push(`role=${el.ariaRole}`);
+  if (el.href) parts.push(el.href.substring(0, 70));
+  if (el.shadowDepth) parts.push(`shadow:${el.shadowDepth}`);
+  return parts.join(' ');
+}
+
+function shouldCaptureUiState(action: RecordedAction): boolean {
+  if (action.type === 'input') {
+    return true;
+  }
+
+  if (action.type !== 'click') {
+    return false;
+  }
+
+  const tag = action.element?.tag || '';
+  const label = `${action.element?.nearbyLabel || ''} ${action.element?.ariaLabel || ''} ${action.element?.text || ''}`.toLowerCase();
+
+  if (tag === 'button' || tag === 'input' || tag.startsWith('lightning-') || tag.startsWith('lst-')) {
+    return true;
+  }
+
+  return /show|filter|apply|more|menu|open|close|available|selected|status|new/.test(label);
+}
+
+// ─── Timer ───────────────────────────────────────────────
+
+function useTimer(startedAt: number | null): string {
+  const [elapsed, setElapsed] = useState(0);
+  useEffect(() => {
+    if (!startedAt) return;
+    const interval = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - startedAt) / 1000));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [startedAt]);
+  const mins = Math.floor(elapsed / 60);
+  const secs = elapsed % 60;
+  return `${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+}
+
+// ─── AI metadata fetcher (naming only, no selectors) ─────
+
+async function fetchToolMetadata(
+  pages: string[],
+  actionLabels: string[],
+  capturedFieldLabels: Record<string, string[]>,
+): Promise<ToolMetadata> {
+  try {
+    const response = await fetch(GUIDE_API_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pages, actionLabels, capturedFieldLabels }),
+    });
+
+    if (response.ok) {
+      return await response.json();
+    }
+  } catch {
+    // AI server not available — fall through to defaults
+  }
+
+  // Fallback: derive metadata heuristically
+  return deriveMetadataLocally(pages, actionLabels);
+}
+
+function deriveMetadataLocally(pages: string[], actionLabels: string[]): ToolMetadata {
+  // Extract object type from URLs
+  const objectTypes = new Set<string>();
+  const templateVars = deriveTemplateVariables(pages);
+
+  for (const url of pages) {
+    try {
+      const parts = new URL(url).pathname.split('/').filter(Boolean);
+      const rIdx = parts.indexOf('r');
+      if (rIdx >= 0 && parts[rIdx + 1]) {
+        objectTypes.add(parts[rIdx + 1]!.toLowerCase());
+      }
+    } catch { /* skip invalid URLs */ }
+  }
+
+  const objects = Array.from(objectTypes);
+  const mainObject = objects[0] || 'page';
+  const actionSummary = actionLabels.slice(0, 3).join(', ').toLowerCase();
+
+  // Build a descriptive name
+  let name = `${mainObject}_actions`;
+  if (actionSummary.includes('navigate')) name = `navigate_${mainObject}`;
+  else if (actionSummary.includes('click')) name = `interact_${mainObject}`;
+  else if (actionSummary.includes('capture') || actionSummary.includes('type')) name = `capture_${mainObject}_data`;
+
+  const properties: Record<string, { type: string; description: string }> = {};
+  const required: string[] = [];
+  for (const paramName of Object.values(templateVars)) {
+    properties[paramName] = { type: 'string', description: `Salesforce ${paramName.replace(/_/g, ' ')}` };
+    required.push(paramName);
+  }
+
+  return {
+    name,
+    description: `Automated tool for ${mainObject}: ${actionLabels.slice(0, 3).join(', ')}`,
+    inputSchema: { type: 'object', properties, required },
+    templateVariables: templateVars,
+  };
+}
+
+// ─── Main Component ──────────────────────────────────────
+
+export function GuideMode({ state, dispatch }: Props) {
+  const session = state.recordingSession;
+  const [building, setBuilding] = useState(false);
+  const [builtYaml, setBuiltYaml] = useState<{
+    app: string;
+    pages: string[];
+    tools: string[];
+    appId: string;
+    savedTo?: string;
+  } | null>(null);
+  const [globalNote, setGlobalNote] = useState('');
+  const feedRef = useRef<HTMLDivElement>(null);
+  const isRecording = session?.status === 'recording';
+  const actions = session?.actions || [];
+  const pageSnapshots = session?.pageSnapshots || {};
+  const snapshotCount = Object.keys(pageSnapshots).length;
+  const timer = useTimer(session?.startedAt ?? null);
+
+  // Track navigation captures separately from same-page UI-state captures.
+  const scannedUrlsRef = useRef<Set<string>>(new Set());
+  const pendingCapturesRef = useRef<Set<string>>(new Set());
+  const lastStateCaptureAtRef = useRef<Map<string, number>>(new Map());
+
+
+  // Listen for ACTION_STREAM and auto-capture on page changes
+  useEffect(() => {
+    const listener = (message: { type: string; payload?: unknown }) => {
+      if (message.type === 'ACTION_STREAM' && message.payload) {
+        const action = message.payload as RecordedAction;
+        dispatch({ type: 'ACTION_RECEIVED', payload: action });
+
+        const url = action.url || (action.metadata?.toUrl as string);
+        if (!url) {
+          return;
+        }
+
+        if (action.type === 'navigate' || !scannedUrlsRef.current.has(url)) {
+          scheduleCapture(url, { reason: 'navigation' });
+        } else if (shouldCaptureUiState(action)) {
+          scheduleCapture(url, { reason: 'state', delayMs: 900 });
+        }
+      }
+    };
+    chrome.runtime.onMessage.addListener(listener);
+    return () => chrome.runtime.onMessage.removeListener(listener);
+  }, [dispatch]);
+
+  // Schedule a capture after the page settles.
+  const scheduleCapture = useCallback((
+    url: string,
+    options?: { reason?: 'navigation' | 'state'; delayMs?: number },
+  ) => {
+    const reason = options?.reason || 'navigation';
+    const delayMs = options?.delayMs ?? (reason === 'state' ? 900 : 3000);
+    const pendingKey = `${reason}:${url}`;
+
+    if (reason === 'navigation' && scannedUrlsRef.current.has(url)) return;
+    if (pendingCapturesRef.current.has(pendingKey)) return;
+
+    if (reason === 'state') {
+      const lastCapturedAt = lastStateCaptureAtRef.current.get(url) || 0;
+      if (Date.now() - lastCapturedAt < 1200) return;
+      lastStateCaptureAtRef.current.set(url, Date.now());
+    } else {
+      scannedUrlsRef.current.add(url);
+    }
+
+    pendingCapturesRef.current.add(pendingKey);
+
+    setTimeout(async () => {
+      try {
+        const snapshot = await runCapture();
+        dispatch({
+          type: 'PAGE_SNAPSHOT_CAPTURED',
+          payload: { url: snapshot.url, snapshot },
+        });
+      } catch (err) {
+        console.warn('Auto-capture failed for', url, err);
+      } finally {
+        pendingCapturesRef.current.delete(pendingKey);
+      }
+    }, delayMs);
+  }, [dispatch]);
+
+  // Auto-scroll on new actions
+  useEffect(() => {
+    if (feedRef.current) {
+      feedRef.current.scrollTop = feedRef.current.scrollHeight;
+    }
+  }, [actions.length]);
+
+  // Initial capture when recording starts
+  const handleToggleRecording = useCallback(async () => {
+    if (isRecording) {
+      await chrome.runtime.sendMessage({ type: 'STOP_RECORDING', payload: {} }).catch(() => {});
+      dispatch({ type: 'STOP_RECORDING' });
+    } else {
+      try {
+        const response = await chrome.runtime.sendMessage({ type: 'START_RECORDING', payload: {} });
+        if (response?.ok) {
+          scannedUrlsRef.current = new Set();
+          pendingCapturesRef.current = new Set();
+          lastStateCaptureAtRef.current = new Map();
+          dispatch({
+            type: 'START_RECORDING',
+            payload: { id: response.sessionId || `rec_${Date.now()}`, startedAt: Date.now() },
+          });
+          setBuiltYaml(null);
+
+          // Capture the current page immediately
+          scheduleCapture(state.currentPageUrl, { reason: 'navigation' });
+        } else {
+          dispatch({ type: 'SET_ERROR', payload: response?.error || 'Failed to start recording' });
+        }
+      } catch (err) {
+        dispatch({ type: 'SET_ERROR', payload: `Recording error: ${err}` });
+      }
+    }
+  }, [isRecording, dispatch, state.currentPageUrl, scheduleCapture]);
+
+  // ─── Build Tool (deterministic + AI naming) ───────────
+
+  const handleBuild = useCallback(async () => {
+    if (actions.length === 0) return;
+    setBuilding(true);
+    dispatch({ type: 'CLEAR_ERROR' });
+
+    try {
+      // 1. Collect action labels and field labels per page
+      const actionLabels = actions.map(getActionLabel);
+      const capturedFieldLabels: Record<string, string[]> = {};
+      for (const snap of Object.values(pageSnapshots)) {
+        const existing = capturedFieldLabels[snap.url] || [];
+        const labels = snap.elements
+          .filter(e => e.label)
+          .map(e => e.label!);
+        capturedFieldLabels[snap.url] = Array.from(new Set([...existing, ...labels]));
+      }
+
+      // 2. Get naming/metadata from AI (or local fallback)
+      const meta = await fetchToolMetadata(
+        session?.pages || [],
+        actionLabels,
+        capturedFieldLabels,
+      );
+      const derivedTemplateVariables = deriveTemplateVariables(session?.pages || []);
+      meta.templateVariables = {
+        ...derivedTemplateVariables,
+        ...meta.templateVariables,
+      };
+
+      for (const [paramName, schema] of Object.entries(
+        Object.fromEntries(Object.values(meta.templateVariables).map(name => [name, name])),
+      )) {
+        if (!meta.inputSchema.properties[paramName]) {
+          meta.inputSchema.properties[paramName] = {
+            type: 'string',
+            description: `Salesforce ${schema.replace(/_/g, ' ')}`,
+          };
+        }
+        if (!meta.inputSchema.required.includes(paramName)) {
+          meta.inputSchema.required.push(paramName);
+        }
+      }
+
+      // If user provided a global note, use it to refine the name
+      if (globalNote.trim()) {
+        const noteWords = globalNote.trim().toLowerCase().replace(/[^a-z0-9 ]/g, '').split(/\s+/);
+        if (noteWords.length <= 5) {
+          meta.name = noteWords.join('_');
+        }
+        meta.description = globalNote.trim();
+      }
+
+      // 3. Build page definitions from captured snapshots
+      const appId = deriveAppId(session?.pages || []);
+      const capturedUrls = Array.from(new Set(Object.values(pageSnapshots).map(snapshot => snapshot.url)));
+      const appDef = buildAppDefinition(appId, session?.pages || capturedUrls);
+      const appYaml = toYamlString(appDef);
+      const pageDefMap = new Map<string, ReturnType<typeof buildPageDefinition>>();
+
+      for (const snapshot of Object.values(pageSnapshots)) {
+        const pageDef = buildPageDefinition(snapshot, appId, meta.templateVariables);
+        pageDefMap.set(pageDef.page.id, pageDef);
+      }
+
+      const pageDefs = Array.from(pageDefMap.values());
+      const pageYamls = pageDefs.map(def => toYamlString(def));
+
+      // 4. Build tool definition from recorded actions + matched elements
+      const toolDef = buildToolDefinition(actions, pageSnapshots, meta, pageDefs);
+      const toolYaml = toYamlString(toolDef);
+
+      let savedTo: string | undefined;
+
+      // 5. Save to server
+      try {
+        const response = await fetch('http://localhost:3456/save-definitions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            appId,
+            app: appDef.app,
+            pages: pageYamls,
+            tools: [toolYaml],
+            captureLabel: meta.name,
+            debug: {
+              sessionId: session?.id,
+              startedAt: session?.startedAt,
+              pages: session?.pages || [],
+              actionLabels,
+              actions,
+              pageSnapshots,
+              toolMetadata: meta,
+              generated: {
+                app: appDef,
+                pages: pageDefs,
+                tool: toolDef,
+              },
+            },
+          }),
+        });
+        if (response.ok) {
+          const payload = await response.json() as { savedTo?: string };
+          savedTo = payload.savedTo;
+        }
+      } catch {
+        // Server may not be running — that's OK, user can still export
+      }
+
+      setBuiltYaml({ app: appYaml, pages: pageYamls, tools: [toolYaml], appId, savedTo });
+
+      dispatch({
+        type: 'SET_GENERATED',
+        payload: {
+          pages: pageDefs.map(def => def as unknown as Record<string, unknown>),
+          tools: [toolDef as unknown as Record<string, unknown>],
+          workflows: [],
+          suggestions: [],
+        },
+      });
+    } catch (err) {
+      dispatch({ type: 'SET_ERROR', payload: `Build failed: ${err instanceof Error ? err.message : err}` });
+    } finally {
+      setBuilding(false);
+    }
+  }, [actions, pageSnapshots, session, globalNote, dispatch]);
+
+  const handleReset = () => {
+    dispatch({ type: 'GUIDE_CLEAR' });
+    dispatch({ type: 'CLEAR_RECORDING' });
+    setBuiltYaml(null);
+    setGlobalNote('');
+    scannedUrlsRef.current = new Set();
+    pendingCapturesRef.current = new Set();
+    lastStateCaptureAtRef.current = new Map();
+  };
+
+  const totalElements = Object.values(pageSnapshots).reduce(
+    (sum, s) => sum + s.elements.length, 0,
+  );
+
+  // ─── Render: Built result view ────────────────────────
+
+  if (builtYaml) {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+        {/* Header */}
+        <div style={{
+          background: '#d4edda', padding: '10px', fontSize: '13px',
+          borderRadius: '6px', marginBottom: '6px', flexShrink: 0,
+        }}>
+          <div style={{ fontWeight: 600, marginBottom: '4px' }}>
+            Tool Built Successfully
+          </div>
+          <div style={{ fontSize: '12px', color: '#155724' }}>
+            {builtYaml.pages.length} page(s), {builtYaml.tools.length} tool(s)
+            {' \u2014 '}{Object.keys(pageSnapshots).length} snapshots captured,{' '}
+            {totalElements} elements captured
+          </div>
+          {builtYaml.savedTo && (
+            <div style={{ fontSize: '11px', color: '#155724', marginTop: '4px', wordBreak: 'break-word' }}>
+              Saved to {builtYaml.savedTo}
+            </div>
+          )}
+        </div>
+
+        {/* YAML preview */}
+        <div ref={feedRef} style={{ flex: 1, overflow: 'auto', padding: '4px' }}>
+          <div style={{ marginBottom: '8px' }}>
+            <div style={{ fontSize: '11px', fontWeight: 600, color: '#7c3aed', marginBottom: '2px' }}>
+              App Definition
+            </div>
+            <pre style={{
+              background: '#f8f9fa', padding: '8px', borderRadius: '4px',
+              fontSize: '10px', overflow: 'auto', whiteSpace: 'pre-wrap',
+              border: '1px solid #e0e0e0', lineHeight: '1.4',
+            }}>
+              {builtYaml.app}
+            </pre>
+          </div>
+
+          {builtYaml.pages.map((yaml, i) => (
+            <div key={`page-${i}`} style={{ marginBottom: '8px' }}>
+              <div style={{ fontSize: '11px', fontWeight: 600, color: '#2563eb', marginBottom: '2px' }}>
+                Page Definition {i + 1}
+              </div>
+              <pre style={{
+                background: '#f8f9fa', padding: '8px', borderRadius: '4px',
+                fontSize: '10px', overflow: 'auto', whiteSpace: 'pre-wrap',
+                border: '1px solid #e0e0e0', lineHeight: '1.4',
+              }}>
+                {yaml}
+              </pre>
+            </div>
+          ))}
+
+          {builtYaml.tools.map((yaml, i) => (
+            <div key={`tool-${i}`} style={{ marginBottom: '8px' }}>
+              <div style={{ fontSize: '11px', fontWeight: 600, color: '#059669', marginBottom: '2px' }}>
+                Tool Definition {i + 1}
+              </div>
+              <pre style={{
+                background: '#f8f9fa', padding: '8px', borderRadius: '4px',
+                fontSize: '10px', overflow: 'auto', whiteSpace: 'pre-wrap',
+                border: '1px solid #e0e0e0', lineHeight: '1.4',
+              }}>
+                {yaml}
+              </pre>
+            </div>
+          ))}
+
+          {/* Capture summary */}
+          <div style={{
+            background: '#f0f7ff', padding: '8px', borderRadius: '4px',
+            fontSize: '11px', border: '1px solid #c3dafe', marginBottom: '8px',
+          }}>
+            <div style={{ fontWeight: 600, marginBottom: '4px' }}>Captured Elements</div>
+            {Object.entries(pageSnapshots).map(([key, snap]) => (
+              <div key={key} style={{ marginBottom: '4px' }}>
+                <div style={{ color: '#2563eb', fontSize: '10px' }}>
+                  {(() => { try { return new URL(snap.url).pathname.substring(0, 60); } catch { return snap.url; } })()}
+                </div>
+                <div style={{ color: '#555' }}>
+                  {snap.elements.filter(e => e.type !== 'field_value').length} interactive,{' '}
+                  {snap.elements.filter(e => e.type === 'field_value').length} field values
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Bottom buttons */}
+        <div style={{
+          display: 'flex', gap: '6px', flexShrink: 0, padding: '6px 0',
+          borderTop: '1px solid #e0e0e0',
+        }}>
+          <button
+            onClick={() => {
+              const allYaml = [builtYaml.app, ...builtYaml.pages, ...builtYaml.tools].join('\n---\n');
+              const blob = new Blob([allYaml], { type: 'text/yaml' });
+              const url = URL.createObjectURL(blob);
+              const a = document.createElement('a');
+              a.href = url;
+              a.download = `${builtYaml.appId}_definitions.yaml`;
+              a.click();
+              URL.revokeObjectURL(url);
+            }}
+            style={{
+              flex: 1, padding: '8px', fontSize: '12px', background: '#0066cc',
+              color: 'white', border: 'none', borderRadius: '6px', cursor: 'pointer',
+              fontWeight: 'bold',
+            }}
+          >
+            Export YAML
+          </button>
+          <button
+            onClick={handleReset}
+            style={{
+              padding: '8px 12px', fontSize: '12px', background: '#6c757d',
+              color: 'white', border: 'none', borderRadius: '6px', cursor: 'pointer',
+            }}
+          >
+            New Session
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ─── Render: Recording view ───────────────────────────
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      {/* Top bar */}
+      <div style={{
+        display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+        padding: '6px 0', borderBottom: '1px solid #e0e0e0', marginBottom: '4px', flexShrink: 0,
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <button
+            onClick={() => void handleToggleRecording()}
+            style={{
+              background: isRecording ? '#dc3545' : '#28a745',
+              color: 'white', border: 'none', borderRadius: '14px',
+              padding: '4px 12px', fontSize: '12px', cursor: 'pointer',
+              display: 'flex', alignItems: 'center', gap: '4px',
+            }}
+          >
+            <span style={{
+              width: '8px', height: '8px', borderRadius: '50%',
+              background: 'white', display: 'inline-block',
+            }} />
+            {isRecording ? timer : 'Record'}
+          </button>
+          <span style={{ fontSize: '11px', color: '#666' }}>
+            {actions.length > 0 && `${actions.length} actions`}
+            {snapshotCount > 0 && ` \u00B7 ${snapshotCount} snapshots captured`}
+            {totalElements > 0 && ` (${totalElements} elements)`}
+          </span>
+        </div>
+        <div style={{ display: 'flex', gap: '4px' }}>
+          {actions.length > 0 && !isRecording && (
+            <button
+              onClick={() => void handleBuild()}
+              disabled={building}
+              style={{
+                fontSize: '11px', padding: '4px 10px',
+                background: building ? '#ccc' : '#0066cc',
+                color: 'white', border: 'none', borderRadius: '4px',
+                cursor: building ? 'wait' : 'pointer', fontWeight: 'bold',
+              }}
+            >
+              {building ? 'Building...' : 'Build Tool'}
+            </button>
+          )}
+          <button
+            onClick={handleReset}
+            style={{
+              fontSize: '11px', padding: '4px 8px', background: '#6c757d', color: 'white',
+              border: 'none', borderRadius: '4px', cursor: 'pointer',
+            }}
+          >
+            Reset
+          </button>
+        </div>
+      </div>
+
+      {/* Error */}
+      {state.error && (
+        <div style={{
+          background: '#f8d7da', color: '#721c24', border: '1px solid #f5c6cb',
+          borderRadius: '4px', padding: '6px 10px', marginBottom: '4px',
+          fontSize: '11px', flexShrink: 0,
+        }}>
+          {state.error}
+          <button onClick={() => dispatch({ type: 'CLEAR_ERROR' })} style={{
+            float: 'right', background: 'none', border: 'none', color: '#721c24',
+            cursor: 'pointer', fontSize: '11px',
+          }}>x</button>
+        </div>
+      )}
+
+      {/* Page scan badges */}
+      {snapshotCount > 0 && (
+        <div style={{
+          padding: '4px 8px', background: '#e8f4fd', borderRadius: '4px',
+          fontSize: '10px', color: '#0c5460', marginBottom: '4px', flexShrink: 0,
+        }}>
+          {Object.entries(pageSnapshots).map(([key, snap]) => (
+            <div key={key} style={{ marginBottom: '2px' }}>
+              Scanned: {snap.elements.length} elements on{' '}
+              {(() => { try { return new URL(snap.url).pathname.substring(0, 50); } catch { return snap.url; } })()}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Action feed */}
+      <div ref={feedRef} style={{ flex: 1, overflow: 'auto' }}>
+        {actions.length === 0 && (
+          <div style={{ color: '#888', fontSize: '13px', textAlign: 'center', marginTop: '30px', lineHeight: '1.8' }}>
+            {isRecording ? (
+              <>
+                Recording... interact with the page.
+                <br />
+                <span style={{ fontSize: '12px', color: '#aaa' }}>
+                  Pages are auto-scanned for elements.<br />
+                  Each action appears here in real-time.
+                </span>
+              </>
+            ) : (
+              <>
+                Click <b>Record</b> and navigate your workflow.
+                <br /><br />
+                <span style={{ fontSize: '12px', color: '#aaa' }}>
+                  1. Record your clicks &amp; navigation<br />
+                  2. Pages are auto-scanned for selectors<br />
+                  3. Stop, then <b>Build Tool</b> — uses real selectors
+                </span>
+              </>
+            )}
+          </div>
+        )}
+
+        {actions.map((action, i) => {
+          const icon = getActionIcon(action.type);
+          const label = getActionLabel(action);
+          const detail = getElementDetail(action);
+
+          return (
+            <div key={action.id || `action-${i}`} style={{
+              borderBottom: '1px solid #eee', padding: '6px 10px',
+              display: 'flex', gap: '6px', alignItems: 'flex-start',
+            }}>
+              <span style={{ fontSize: '13px', flexShrink: 0, marginTop: '1px' }}>{icon}</span>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: '12px', fontWeight: 500, wordBreak: 'break-word' }}>
+                  {i + 1}. {label}
+                </div>
+                {detail && (
+                  <div style={{ color: '#999', fontSize: '10px', marginTop: '1px' }}>{detail}</div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Global context note */}
+      {actions.length > 0 && !isRecording && (
+        <div style={{
+          padding: '6px 0', borderTop: '1px solid #e0e0e0', flexShrink: 0,
+        }}>
+          <input
+            value={globalNote}
+            onChange={(e) => setGlobalNote(e.target.value)}
+            placeholder="Tool name/description (optional, e.g. 'navigate_to_related_cases')"
+            style={{
+              width: '100%', padding: '8px', fontSize: '12px',
+              border: '1px solid #ccc', borderRadius: '6px', boxSizing: 'border-box',
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Helpers ────────────────────────────────────────────
+
+function deriveAppId(pages: string[]): string {
+  for (const url of pages) {
+    try {
+      const host = new URL(url).hostname;
+      // e.g. revance-oce--fulldev.sandbox.lightning.force.com -> revance_oce_fulldev
+      const parts = host.split('.')[0]!.replace(/--/g, '_').replace(/-/g, '_');
+      return parts;
+    } catch { /* skip */ }
+  }
+  return 'app';
+}

--- a/packages/extension/src/panel/components/RecordMode.tsx
+++ b/packages/extension/src/panel/components/RecordMode.tsx
@@ -37,6 +37,10 @@ function getActionLabel(action: RecordedAction): string {
     case 'input': {
       const field = el?.nearbyLabel || el?.ariaLabel || el?.placeholder || el?.tag || 'field';
       const val = action.metadata?.inputValue;
+      if (action.metadata?.inputKind === 'select') {
+        const selected = typeof val === 'string' ? val.substring(0, 20) : 'option';
+        return `Select "${selected}${typeof val === 'string' && val.length > 20 ? '...' : ''}" in "${field}"`;
+      }
       return `Type in "${field}"${val ? `: "${val.substring(0, 20)}${val.length > 20 ? '...' : ''}"` : ''}`;
     }
     case 'navigate': {

--- a/packages/extension/src/panel/index.tsx
+++ b/packages/extension/src/panel/index.tsx
@@ -3,9 +3,10 @@ import { createRoot } from 'react-dom/client';
 import { CaptureMode } from './components/CaptureMode.js';
 import { ExecuteMode } from './components/ExecuteMode.js';
 import { RecordMode } from './components/RecordMode.js';
+import { GuideMode } from './components/GuideMode.js';
 import { sidePanelReducer, initialState } from './reducer.js';
 
-type Mode = 'capture' | 'execute' | 'record';
+type Mode = 'guide' | 'record' | 'capture' | 'execute';
 
 const TAB_STYLE = (active: boolean) => ({
   fontWeight: active ? 'bold' as const : 'normal' as const,
@@ -20,11 +21,14 @@ const TAB_STYLE = (active: boolean) => ({
 
 function App() {
   const [state, dispatch] = useReducer(sidePanelReducer, initialState);
-  const [mode, setMode] = useState<Mode>('record');
+  const [mode, setMode] = useState<Mode>('guide');
 
   return (
     <div style={{ fontFamily: 'system-ui, sans-serif', padding: '12px', height: '100vh', display: 'flex', flexDirection: 'column' }}>
       <header style={{ display: 'flex', gap: '6px', marginBottom: '12px', flexShrink: 0 }}>
+        <button onClick={() => setMode('guide')} style={TAB_STYLE(mode === 'guide')}>
+          Guide
+        </button>
         <button onClick={() => setMode('record')} style={TAB_STYLE(mode === 'record')}>
           Record
         </button>
@@ -36,6 +40,7 @@ function App() {
         </button>
       </header>
       <div style={{ flex: 1, overflow: 'auto' }}>
+        {mode === 'guide' && <GuideMode state={state} dispatch={dispatch} />}
         {mode === 'record' && <RecordMode state={state} dispatch={dispatch} />}
         {mode === 'capture' && <CaptureMode state={state} dispatch={dispatch} />}
         {mode === 'execute' && <ExecuteMode state={state} dispatch={dispatch} />}

--- a/packages/extension/src/panel/reducer.ts
+++ b/packages/extension/src/panel/reducer.ts
@@ -14,6 +14,8 @@ export interface RecordingSessionState {
   actions: RecordedAction[];
   pages: string[];
   status: 'recording' | 'analyzing' | 'complete' | 'error';
+  /** Timestamped capture snapshots keyed by capture id — real selectors from page scan */
+  pageSnapshots: Record<string, CaptureSnapshot>;
 }
 
 export interface GeneratedDefinitions {
@@ -62,8 +64,27 @@ export interface CaptureSnapshot {
   timestamp: number;
 }
 
+// ─── Guide Chat Types ──────────────────────────────────
+
+export interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  timestamp: number;
+  /** DOM snapshot attached to this message (user messages only) */
+  snapshot?: { url: string; elements: number };
+}
+
+export interface GuideState {
+  messages: ChatMessage[];
+  loading: boolean;
+  /** Accumulated definitions built during the guided session */
+  definitions: GeneratedDefinitions | null;
+  sessionId: string;
+}
+
 export interface SidePanelState {
-  mode: 'capture' | 'execute' | 'record';
+  mode: 'capture' | 'execute' | 'record' | 'guide';
   tools: ToolSchema[];
   suggestedTools: ToolSchema[];
   currentPageUrl: string;
@@ -78,12 +99,14 @@ export interface SidePanelState {
   // Recording state
   recordingSession: RecordingSessionState | null;
   generatedDefinitions: GeneratedDefinitions | null;
+  // Guide chat state
+  guide: GuideState;
 }
 
 // ─── Actions ────────────────────────────────────────────
 
 export type SidePanelAction =
-  | { type: 'SWITCH_MODE'; mode: 'capture' | 'execute' | 'record' }
+  | { type: 'SWITCH_MODE'; mode: 'capture' | 'execute' | 'record' | 'guide' }
   | { type: 'SET_TOOLS'; payload: ToolSchema[] }
   | { type: 'SET_SUGGESTED_TOOLS'; payload: ToolSchema[] }
   | { type: 'UPDATE_PAGE'; payload: { url: string; title: string } }
@@ -102,7 +125,13 @@ export type SidePanelAction =
   | { type: 'ACTION_RECEIVED'; payload: RecordedAction }
   | { type: 'SET_ANALYZING' }
   | { type: 'SET_GENERATED'; payload: GeneratedDefinitions }
-  | { type: 'CLEAR_RECORDING' };
+  | { type: 'CLEAR_RECORDING' }
+  | { type: 'PAGE_SNAPSHOT_CAPTURED'; payload: { url: string; snapshot: CaptureSnapshot } }
+  // Guide chat actions
+  | { type: 'GUIDE_ADD_USER_MESSAGE'; payload: { content: string; snapshot?: { url: string; elements: number } } }
+  | { type: 'GUIDE_ADD_ASSISTANT_MESSAGE'; payload: { content: string; definitions?: GeneratedDefinitions } }
+  | { type: 'GUIDE_SET_LOADING'; payload: boolean }
+  | { type: 'GUIDE_CLEAR' };
 
 // ─── Initial state ──────────────────────────────────────
 
@@ -121,6 +150,12 @@ export const initialState: SidePanelState = {
   snapshot: null,
   recordingSession: null,
   generatedDefinitions: null,
+  guide: {
+    messages: [],
+    loading: false,
+    definitions: null,
+    sessionId: `guide_${Date.now()}`,
+  },
 };
 
 // ─── Reducer ────────────────────────────────────────────
@@ -195,6 +230,7 @@ export function sidePanelReducer(state: SidePanelState, action: SidePanelAction)
           actions: [],
           pages: [state.currentPageUrl],
           status: 'recording',
+          pageSnapshots: {},
         },
         generatedDefinitions: null,
         error: null,
@@ -238,11 +274,81 @@ export function sidePanelReducer(state: SidePanelState, action: SidePanelAction)
         loading: false,
       };
 
+    case 'PAGE_SNAPSHOT_CAPTURED':
+      if (!state.recordingSession) return state;
+      const snapshotKey = `${action.payload.url}#${action.payload.snapshot.timestamp}`;
+      return {
+        ...state,
+        recordingSession: {
+          ...state.recordingSession,
+          pageSnapshots: {
+            ...state.recordingSession.pageSnapshots,
+            [snapshotKey]: action.payload.snapshot,
+          },
+        },
+      };
+
     case 'CLEAR_RECORDING':
       return {
         ...state,
         recordingSession: null,
         generatedDefinitions: null,
+      };
+
+    // ── Guide Chat ───────────────────────────────────────
+
+    case 'GUIDE_ADD_USER_MESSAGE':
+      return {
+        ...state,
+        guide: {
+          ...state.guide,
+          messages: [
+            ...state.guide.messages,
+            {
+              id: `msg_${Date.now()}`,
+              role: 'user',
+              content: action.payload.content,
+              timestamp: Date.now(),
+              snapshot: action.payload.snapshot,
+            },
+          ],
+        },
+      };
+
+    case 'GUIDE_ADD_ASSISTANT_MESSAGE':
+      return {
+        ...state,
+        guide: {
+          ...state.guide,
+          messages: [
+            ...state.guide.messages,
+            {
+              id: `msg_${Date.now()}`,
+              role: 'assistant',
+              content: action.payload.content,
+              timestamp: Date.now(),
+            },
+          ],
+          loading: false,
+          definitions: action.payload.definitions ?? state.guide.definitions,
+        },
+      };
+
+    case 'GUIDE_SET_LOADING':
+      return {
+        ...state,
+        guide: { ...state.guide, loading: action.payload },
+      };
+
+    case 'GUIDE_CLEAR':
+      return {
+        ...state,
+        guide: {
+          messages: [],
+          loading: false,
+          definitions: null,
+          sessionId: `guide_${Date.now()}`,
+        },
       };
 
     default:

--- a/packages/extension/src/panel/reducer.ts
+++ b/packages/extension/src/panel/reducer.ts
@@ -274,7 +274,7 @@ export function sidePanelReducer(state: SidePanelState, action: SidePanelAction)
         loading: false,
       };
 
-    case 'PAGE_SNAPSHOT_CAPTURED':
+    case 'PAGE_SNAPSHOT_CAPTURED': {
       if (!state.recordingSession) return state;
       const snapshotKey = `${action.payload.url}#${action.payload.snapshot.timestamp}`;
       return {
@@ -287,6 +287,7 @@ export function sidePanelReducer(state: SidePanelState, action: SidePanelAction)
           },
         },
       };
+    }
 
     case 'CLEAR_RECORDING':
       return {

--- a/packages/extension/src/panel/utils/run-capture.ts
+++ b/packages/extension/src/panel/utils/run-capture.ts
@@ -1,0 +1,314 @@
+/**
+ * Shared utility to run page capture on the active tab.
+ * Extracted from CaptureMode so GuideMode can reuse the same logic.
+ */
+
+import type { CaptureSnapshot } from '../reducer.js';
+
+/**
+ * Runs the page scanner on the active tab and returns captured elements.
+ * This is the same DOM-walking logic from CaptureMode — finds interactive elements,
+ * Salesforce field labels+values, shadow DOM paths, etc.
+ */
+export function runCapture(): Promise<CaptureSnapshot> {
+  return new Promise((resolve, reject) => {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      const tab = tabs[0];
+      if (!tab?.id) {
+        reject(new Error('No active tab found'));
+        return;
+      }
+
+      chrome.scripting.executeScript(
+        {
+          target: { tabId: tab.id },
+          func: scanPageDOM,
+        },
+        (results) => {
+          if (chrome.runtime.lastError) {
+            reject(new Error(chrome.runtime.lastError.message || 'Capture failed'));
+            return;
+          }
+          const result = results?.[0]?.result as CaptureSnapshot | undefined;
+          if (!result) {
+            reject(new Error('No capture result returned'));
+            return;
+          }
+          resolve(result);
+        },
+      );
+    });
+  });
+}
+
+/**
+ * The actual DOM scanning function — runs in the page context via executeScript.
+ * Must be self-contained (no imports, no closures).
+ */
+function scanPageDOM(): {
+  url: string;
+  title: string;
+  elements: Array<{
+    id: string;
+    tag: string;
+    type?: string;
+    ariaLabel?: string;
+    text?: string;
+    xPath: string;
+    cssSelector?: string;
+    label?: string;
+    shadowPath?: string;
+    href?: string;
+    value?: string;
+  }>;
+  timestamp: number;
+} {
+  const elements: Array<{
+    id: string;
+    tag: string;
+    type?: string;
+    ariaLabel?: string;
+    text?: string;
+    xPath: string;
+    cssSelector?: string;
+    label?: string;
+    shadowPath?: string;
+    href?: string;
+    value?: string;
+  }> = [];
+
+  const interactiveTags = new Set([
+    'button', 'input', 'select', 'a', 'textarea',
+  ]);
+  const interactiveRoles = new Set([
+    'button', 'textbox', 'combobox', 'listbox', 'checkbox',
+    'radio', 'switch', 'slider', 'searchbox', 'spinbutton',
+    'link', 'menuitem', 'tab', 'option',
+  ]);
+
+  function buildCssSelector(el: Element): string {
+    if (el.id) return `#${el.id}`;
+
+    const tag = el.tagName.toLowerCase();
+    const testId = el.getAttribute('data-testid') || el.getAttribute('data-aura-rendered-by');
+    if (testId) return `[data-testid="${testId}"]`;
+
+    if (el.classList.length > 0) {
+      const classSelector = `${tag}.${Array.from(el.classList).map(c => CSS.escape(c)).join('.')}`;
+      try {
+        if (el.ownerDocument.querySelectorAll(classSelector).length === 1) {
+          return classSelector;
+        }
+      } catch {
+        // Fall through to nth-of-type selector below.
+      }
+    }
+
+    const parent = el.parentElement;
+    if (parent) {
+      const siblings = Array.from(parent.children).filter(c => c.tagName === el.tagName);
+      if (siblings.length > 1) {
+        const idx = siblings.indexOf(el) + 1;
+        return `${tag}:nth-of-type(${idx})`;
+      }
+    }
+
+    return tag;
+  }
+
+  function findLabel(el: Element): string | undefined {
+    const ariaLabel = el.getAttribute('aria-label');
+    if (ariaLabel) return ariaLabel;
+
+    const id = el.id;
+    if (id) {
+      const rootNode = el.getRootNode() as Document | ShadowRoot;
+      const label = ('querySelector' in rootNode ? rootNode.querySelector(`label[for="${id}"]`) : null) as HTMLLabelElement | null;
+      if (label?.textContent) return label.textContent.trim();
+    }
+
+    const parentLabel = el.closest('label');
+    if (parentLabel?.textContent) return parentLabel.textContent.trim().substring(0, 60);
+
+    const parent = el.parentElement;
+    if (parent) {
+      const prev = el.previousElementSibling;
+      if (prev?.tagName === 'LABEL' || prev?.tagName === 'SPAN') {
+        const text = prev.textContent?.trim();
+        if (text && text.length < 60) return text;
+      }
+      const sldsLabel = parent.closest('.slds-form-element')?.querySelector('.slds-form-element__label');
+      if (sldsLabel?.textContent) return sldsLabel.textContent.trim();
+    }
+
+    const placeholder = el.getAttribute('placeholder');
+    if (placeholder) return placeholder;
+
+    return undefined;
+  }
+
+  function buildShadowPath(el: Element): string {
+    const parts: string[] = [];
+    let current: Element | null = el;
+
+    while (current) {
+      const root: Node = current.getRootNode();
+      if (root instanceof ShadowRoot) {
+        const host: Element = root.host;
+        let hostSelector = host.tagName.toLowerCase();
+        if (host.id) hostSelector = `#${host.id}`;
+        else if (host.className && typeof host.className === 'string') {
+          const cls = host.className.trim().split(/\s+/)[0];
+          if (cls) hostSelector = `${host.tagName.toLowerCase()}.${cls}`;
+        }
+        parts.unshift(`${hostSelector} >> shadow >> ${buildElementSelector(current)}`);
+        current = host.parentElement;
+      } else {
+        parts.unshift(buildElementSelector(current));
+        break;
+      }
+    }
+
+    return parts.join(' > ');
+  }
+
+  function buildElementSelector(el: Element): string {
+    const tag = el.tagName.toLowerCase();
+    if (el.id) return `#${el.id}`;
+    if (el.className && typeof el.className === 'string') {
+      const cls = el.className.trim().split(/\s+/).slice(0, 2).join('.');
+      if (cls) return `${tag}.${cls}`;
+    }
+    return tag;
+  }
+
+  // ── First pass: interactive elements via stack-based DOM walk ──
+  const seen = new Set<string>();
+  const stack: Array<Document | ShadowRoot | Element> = [document];
+
+  while (stack.length > 0 && elements.length < 500) {
+    const root = stack.pop()!;
+
+    const children = root instanceof Element
+      ? root.children
+      : (root as Document | ShadowRoot).children ?? [];
+
+    for (let i = children.length - 1; i >= 0; i--) {
+      const el = children[i]!;
+      const tag = el.tagName.toLowerCase();
+      const role = el.getAttribute('role');
+
+      const isInteractive =
+        interactiveTags.has(tag) ||
+        (role && interactiveRoles.has(role)) ||
+        el.hasAttribute('contenteditable') ||
+        el.hasAttribute('aria-label') ||
+        el.hasAttribute('data-testid');
+
+      if (isInteractive) {
+        const cssSelector = buildCssSelector(el);
+
+        const label = findLabel(el);
+
+        let directText: string | undefined;
+        if (el.childNodes.length <= 5) {
+          directText = (el.textContent || '').trim().substring(0, 80) || undefined;
+        } else {
+          const textParts: string[] = [];
+          for (let j = 0; j < el.childNodes.length; j++) {
+            const node = el.childNodes[j]!;
+            if (node.nodeType === Node.TEXT_NODE) {
+              const t = (node.textContent || '').trim();
+              if (t) textParts.push(t);
+            }
+          }
+          directText = textParts.join(' ').substring(0, 80) || undefined;
+        }
+
+        const shadowPath = el.getRootNode() instanceof ShadowRoot
+          ? buildShadowPath(el)
+          : undefined;
+
+        const displayLabel = label || directText || el.getAttribute('aria-label') || el.getAttribute('title') || el.getAttribute('placeholder') || undefined;
+
+        const dedupeKey = `${tag}|${displayLabel || ''}|${directText || ''}|${cssSelector}`;
+        if (seen.has(dedupeKey) && !el.id) {
+          // skip duplicate, still push children
+        } else {
+          seen.add(dedupeKey);
+
+          const href = tag === 'a' ? (el as HTMLAnchorElement).href || undefined : undefined;
+          const inputValue = (tag === 'input' || tag === 'textarea' || tag === 'select')
+            ? (el as HTMLInputElement).value || undefined
+            : undefined;
+
+          elements.push({
+            id: el.id || `${tag}_${elements.length}`,
+            tag,
+            type: (el as HTMLInputElement).type || undefined,
+            ariaLabel: el.getAttribute('aria-label') || undefined,
+            text: directText || undefined,
+            xPath: el.id ? `//*[@id="${el.id}"]` : '',
+            cssSelector,
+            label: displayLabel,
+            shadowPath,
+            href,
+            value: inputValue,
+          });
+        }
+      }
+
+      if (el.shadowRoot) {
+        stack.push(el.shadowRoot);
+      }
+      stack.push(el);
+    }
+  }
+
+  // ── Second pass: Salesforce detail page field values ──
+  const formElements = document.querySelectorAll('.slds-form-element, .slds-form-element_stacked');
+  for (const fe of formElements) {
+    if (elements.length >= 500) break;
+
+    const labelEl = fe.querySelector('.slds-form-element__label, .test-id__field-label');
+    const valueEl = fe.querySelector('.slds-form-element__control, .test-id__field-value');
+    if (!labelEl || !valueEl) continue;
+
+    const fieldLabel = labelEl.textContent?.trim();
+    if (!fieldLabel || fieldLabel.length < 2) continue;
+
+    const fieldValue = valueEl.textContent?.trim().substring(0, 200);
+    if (!fieldValue) continue;
+
+    const linkEl = valueEl.querySelector('a');
+    const fieldHref = linkEl?.href || undefined;
+
+    const fieldSnake = fieldLabel.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '');
+    const dedupeKey = `field_value|${fieldSnake}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+
+    const fieldCss = buildCssSelector(fe);
+
+    elements.push({
+      id: `field_${fieldSnake || elements.length}`,
+      tag: fieldHref ? 'a' : 'span',
+      type: 'field_value',
+      ariaLabel: undefined,
+      text: fieldValue.substring(0, 80),
+      xPath: '',
+      cssSelector: fieldCss,
+      label: fieldLabel,
+      shadowPath: undefined,
+      href: fieldHref,
+      value: fieldValue,
+    });
+  }
+
+  return {
+    url: window.location.href,
+    title: document.title,
+    elements,
+    timestamp: Date.now(),
+  };
+}

--- a/packages/extension/src/service-worker/index.ts
+++ b/packages/extension/src/service-worker/index.ts
@@ -223,20 +223,22 @@ export async function handleStartRecording(
     status: 'recording',
   };
 
-  // Inject content script if not already present, then start recording
+  // Try sending START_RECORDING first — if content script is already loaded
+  // (via manifest content_scripts), this will succeed without re-injection.
+  try {
+    await chromeApi.tabs.sendMessage(tabId, { type: 'START_RECORDING' });
+    sendResponse({ ok: true, sessionId: state.recordingSession.id });
+    return;
+  } catch {
+    // Content script not present — inject it
+  }
+
   try {
     await chromeApi.scripting.executeScript({
       target: { tabId },
       files: ['content-script.js'],
     });
-  } catch {
-    // Already injected or injection failed — try sending anyway
-  }
-
-  // Small delay to let the content script initialize
-  await new Promise(resolve => setTimeout(resolve, 100));
-
-  try {
+    await new Promise(resolve => setTimeout(resolve, 100));
     await chromeApi.tabs.sendMessage(tabId, { type: 'START_RECORDING' });
     sendResponse({ ok: true, sessionId: state.recordingSession.id });
   } catch (error: unknown) {
@@ -374,6 +376,23 @@ export function initServiceWorker(chromeApi: typeof chrome): ServiceWorkerState 
 
   const router = createServiceWorkerMessageRouter(state, chromeApi);
   chromeApi.runtime.onMessage.addListener(router);
+
+  // Re-send START_RECORDING to content script after tab navigation
+  // (content script is re-injected by manifest but needs the recording signal)
+  if (chromeApi.tabs?.onUpdated) {
+    chromeApi.tabs.onUpdated.addListener((tabId, changeInfo) => {
+      if (
+        changeInfo.status === 'complete' &&
+        state.recordingSession &&
+        state.recordingSession.status === 'recording' &&
+        state.recordingSession.tabId === tabId
+      ) {
+        chromeApi.tabs.sendMessage(tabId, { type: 'START_RECORDING' }).catch(() => {
+          // Content script not ready yet
+        });
+      }
+    });
+  }
 
   // Load config from local storage
   chromeApi.storage.local.get(['bridge_api_url']).then((result: Record<string, unknown>) => {

--- a/scripts/analyze-server.ts
+++ b/scripts/analyze-server.ts
@@ -9,6 +9,8 @@
  * Usage: npx tsx scripts/analyze-server.ts
  */
 import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
 import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime';
 
 const PORT = 3456;
@@ -47,17 +49,44 @@ function buildPrompt(session: { actions: unknown[]; pages: string[]; duration: n
 
   return `You are a semantic web automation expert. Analyze this recorded browser session and generate semantic definitions for the WebMCP Bridge framework.
 
+## CRITICAL NAMING RULES
+- ALL identifiers (page id, field id, tool name, workflow name, app id) MUST use snake_case: lowercase letters, digits, underscores only.
+- Pattern: ^[a-z0-9_]+$
+- Examples: account_detail, navigate_to_cases, filter_status, case_detail_page
+- NEVER use kebab-case (no hyphens). "account-detail" is INVALID, use "account_detail".
+
 ## Semantic Definition Schema
 
-### PageDefinition
-Each page has:
-- id: kebab-case identifier
-- app: app identifier (derive from the domain)
-- url_pattern: URL pattern with wildcards (e.g., "/lightning/r/Account/*/view")
-- url_template: template with variables (e.g., "{{app.base_url}}/lightning/r/Account/{{account_id}}/view")
-- wait_for: CSS selector indicating page is ready (prefer .slds-page-header for Salesforce, or main content selectors)
-- fields: interactive elements (buttons, inputs, tabs) — each has id, label, type, selectors, interaction
-- outputs: readable values — each has id, label, selectors, capture_strategies
+### PageDefinition (YAML key: "page:")
+\`\`\`yaml
+page:
+  id: account_detail          # snake_case
+  app: my_app_id              # snake_case, must match app.id
+  url_pattern: "/lightning/r/Account/*/view"
+  url_template: "{{app.base_url}}/lightning/r/Account/{{account_id}}/view"
+  wait_for: ".slds-page-header"  # CSS selector for page ready
+  fields:                     # interactive elements
+    - id: details_tab         # snake_case
+      label: "Details"
+      type: action_button
+      selectors:              # MUST include 2+ strategies from recorded data
+        - strategy: aria
+          role: tab
+          name: "Details"
+          confidence: 0.95
+        - strategy: css
+          selector: "#detailTab__item"
+          confidence: 0.85
+      interaction:
+        type: click
+  outputs:                    # readable values
+    - id: account_name
+      label: "Account Name"
+      selectors:
+        - strategy: css
+          selector: ".slds-page-header__title"
+          confidence: 0.90
+\`\`\`
 
 ### Selector Strategies (ordered by preference)
 1. aria: { strategy: "aria", role: "button", name: "Details", confidence: 0.95 }
@@ -65,29 +94,62 @@ Each page has:
 3. text: { strategy: "text", text: "Submit", exact: true, confidence: 0.85 }
 4. js: { strategy: "js", expression: "(() => { ... })()", confidence: 0.80 }
 
+IMPORTANT: Use the EXACT selectors from the recorded session data. The recorded [aria:] and [css:] values come from the actual DOM — use them directly. Do NOT invent or guess selectors.
+
 ### Field types
 text, picklist, lookup, checkbox, date, datetime, number, textarea, file, action_button, radio, toggle
 
 ### Interaction types
 click, text_input, select, check, fill
 
-### ToolDefinition
-Each tool has:
-- name: kebab-case
-- description: what the tool does
-- inputSchema: JSON Schema for inputs
-- bridge: { page: "page_id", steps: [...], returns: {...} }
+### ToolDefinition (YAML key: "tool:")
+\`\`\`yaml
+tool:
+  name: navigate_to_cases     # snake_case
+  description: "Navigate to account cases"
+  inputSchema:
+    type: object
+    properties:
+      account_id:
+        type: string
+        description: "Salesforce Account ID"
+    required: [account_id]
+  bridge:
+    page: account_detail      # snake_case page id
+    steps:
+      - navigate:
+          page: account_detail
+          params:
+            account_id: "{{account_id}}"
+      - wait: 2000
+      - interact:
+          field: account_detail.fields.details_tab
+          action: click
+    returns:
+      account_id: "{{account_id}}"
+\`\`\`
 
-### Tool step types
-- navigate: { page: "page_id", params: {} }
-- interact: { field: "page_id.fields.field_id", value: "{{input_var}}", action: "click" }
-- capture: { from: "page_id.outputs.output_id", store_as: "var_name" }
-- wait: 3000
+### ToolDefinition inputSchema rules
+- inputSchema must be a valid JSON Schema with only: type, properties, required, description
+- Do NOT use "default" in property definitions — it will fail validation
 
-### WorkflowDefinition
-Chains multiple tools:
-- name, description, input, steps
-- Each step: { tool: "tool_name", params: {}, capture: {} }
+### WorkflowDefinition (YAML key: "workflow:")
+\`\`\`yaml
+workflow:
+  name: my_workflow              # snake_case
+  description: "Does X then Y"
+  input:                         # NOTE: "input" not "inputSchema"
+    account_id:
+      type: string
+      description: "Salesforce Account ID"
+  steps:
+    - tool: first_tool_name
+      params:
+        account_id: "{{account_id}}"
+    - tool: second_tool_name
+      params:
+        some_param: "{{some_value}}"
+\`\`\`
 
 ## Recorded Session (${session.actions.length} actions, ${session.pages.length} pages, ${Math.round(session.duration / 1000)}s)
 ${actionSummary}
@@ -95,18 +157,30 @@ ${actionSummary}
 ## Instructions
 
 1. Create a PageDefinition for each unique URL pattern (collapse similar URLs into patterns with *)
-2. For each page, identify fields (interactive elements the user clicked/typed in) and outputs (values that were read/displayed)
-3. Use the element context to pick the best selector strategy:
-   - If aria role+name available -> use aria strategy
-   - If element has unique ID -> use css strategy
-   - If element is in shadow DOM -> use js strategy with an IIFE that walks labels
-   - Always include confidence scores
+2. For each page, identify fields (interactive elements the user clicked/typed in) and outputs (values displayed)
+3. SELECTOR RULES — this is critical for the definitions to work:
+   - Use the EXACT aria role+name from the recorded [aria:] data — do not modify or guess
+   - Use the EXACT CSS selector from the recorded [css:] data — do not simplify or guess
+   - ALWAYS include at least 2 selector strategies per field as fallbacks
+   - If element is in shadow DOM (shadow: depth > 0) -> add a js strategy with an IIFE
 4. Create ToolDefinitions that group logical action sequences
 5. If multiple tools are used in sequence, create a WorkflowDefinition chaining them
 6. Add practical suggestions for improving the definitions
 
+## App Definition
+Also generate an app definition:
+\`\`\`yaml
+app:
+  id: my_app_id               # snake_case, derived from domain
+  name: "Human Readable Name"
+  base_url: "https://example.com"  # base URL from session pages
+  url_patterns:
+    - "/path/pattern/*"
+\`\`\`
+
 Respond with valid JSON only (no markdown fencing):
 {
+  "app": { ... },
   "pages": [...],
   "tools": [...],
   "workflows": [...],
@@ -146,6 +220,318 @@ async function analyzeSession(session: Record<string, unknown>): Promise<unknown
   return JSON.parse(cleaned);
 }
 
+// ─── YAML Writer ─────────────────────────────────────────
+
+const EXAMPLES_DIR = path.join(process.cwd(), 'semantic-examples');
+
+function sanitizeDirName(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, '_')
+    .replace(/^_+|_+$/g, '') || 'captured_app';
+}
+
+function formatTimestamp(date = new Date()): string {
+  const pad = (num: number): string => String(num).padStart(2, '0');
+  return `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}_${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`;
+}
+
+function resolveOutputDirectory(appDirName: string, captureLabel?: string): { outDir: string; dirName: string; relativeDir: string } {
+  const baseName = sanitizeDirName(appDirName);
+  const preferredDir = path.join(EXAMPLES_DIR, baseName);
+
+  if (!fs.existsSync(preferredDir)) {
+    return {
+      outDir: preferredDir,
+      dirName: baseName,
+      relativeDir: path.join('semantic-examples', baseName),
+    };
+  }
+
+  const suffixParts = ['capture', formatTimestamp()];
+  const safeLabel = captureLabel ? sanitizeDirName(captureLabel).slice(0, 40) : '';
+  if (safeLabel) {
+    suffixParts.push(safeLabel);
+  }
+
+  let dirName = `${baseName}_${suffixParts.join('_')}`;
+  let attempt = 2;
+  while (fs.existsSync(path.join(EXAMPLES_DIR, dirName))) {
+    dirName = `${baseName}_${suffixParts.join('_')}_${attempt++}`;
+  }
+
+  return {
+    outDir: path.join(EXAMPLES_DIR, dirName),
+    dirName,
+    relativeDir: path.join('semantic-examples', dirName),
+  };
+}
+
+function toYaml(obj: unknown, indent = 0): string {
+  const pad = '  '.repeat(indent);
+  if (obj === null || obj === undefined) return 'null';
+  if (typeof obj === 'boolean') return String(obj);
+  if (typeof obj === 'number') return String(obj);
+  if (typeof obj === 'string') {
+    if (obj.includes('{{') || obj.includes(':') || obj.includes('#') || obj.includes('"') || obj.includes("'") || obj.startsWith('*') || obj === '') {
+      return `"${obj.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+    }
+    return obj;
+  }
+  if (Array.isArray(obj)) {
+    if (obj.length === 0) return '[]';
+    return obj.map(item => {
+      if (typeof item === 'object' && item !== null) {
+        const inner = toYaml(item, indent + 1).trimStart();
+        return `${pad}- ${inner}`;
+      }
+      return `${pad}- ${toYaml(item)}`;
+    }).join('\n');
+  }
+  if (typeof obj === 'object') {
+    const entries = Object.entries(obj as Record<string, unknown>);
+    if (entries.length === 0) return '{}';
+    return entries.map(([key, val]) => {
+      if (typeof val === 'object' && val !== null && !Array.isArray(val)) {
+        return `${pad}${key}:\n${toYaml(val, indent + 1)}`;
+      }
+      if (Array.isArray(val)) {
+        return `${pad}${key}:\n${toYaml(val, indent + 1)}`;
+      }
+      return `${pad}${key}: ${toYaml(val)}`;
+    }).join('\n');
+  }
+  return String(obj);
+}
+
+function saveDefinitions(
+  result: Record<string, unknown>,
+  appDirName: string,
+  captureLabel?: string,
+): { saved: string[]; relativeDir: string; dirName: string } {
+  const { outDir, relativeDir, dirName } = resolveOutputDirectory(appDirName, captureLabel);
+  const saved: string[] = [];
+
+  // Create directories
+  fs.mkdirSync(path.join(outDir, 'pages'), { recursive: true });
+  fs.mkdirSync(path.join(outDir, 'tools'), { recursive: true });
+  fs.mkdirSync(path.join(outDir, 'workflows'), { recursive: true });
+
+  // Save app
+  const appDef = result.app as Record<string, unknown> | undefined;
+  if (appDef) {
+    const yaml = toYaml({ app: appDef });
+    const filePath = path.join(outDir, 'app.yaml');
+    fs.writeFileSync(filePath, yaml + '\n');
+    saved.push(filePath);
+  }
+
+  // Save pages
+  const pages = result.pages as Array<Record<string, unknown>> | undefined;
+  if (pages) {
+    for (const pageDef of pages) {
+      const id = pageDef.id as string;
+      if (!id) continue;
+      const yaml = toYaml({ page: pageDef });
+      const filePath = path.join(outDir, 'pages', `${id}.yaml`);
+      fs.writeFileSync(filePath, yaml + '\n');
+      saved.push(filePath);
+    }
+  }
+
+  // Save tools
+  const tools = result.tools as Array<Record<string, unknown>> | undefined;
+  if (tools) {
+    for (const toolDef of tools) {
+      const name = toolDef.name as string;
+      if (!name) continue;
+      const yaml = toYaml({ tool: toolDef });
+      const filePath = path.join(outDir, 'tools', `${name}.yaml`);
+      fs.writeFileSync(filePath, yaml + '\n');
+      saved.push(filePath);
+    }
+  }
+
+  // Save workflows
+  const workflows = result.workflows as Array<Record<string, unknown>> | undefined;
+  if (workflows) {
+    for (const wfDef of workflows) {
+      const name = wfDef.name as string;
+      if (!name) continue;
+      const yaml = toYaml({ workflow: wfDef });
+      const filePath = path.join(outDir, 'workflows', `${name}.yaml`);
+      fs.writeFileSync(filePath, yaml + '\n');
+      saved.push(filePath);
+    }
+  }
+
+  return { saved, relativeDir, dirName };
+}
+
+// ─── Guide Mode (Conversational) ─────────────────────────
+
+const GUIDE_SYSTEM_PROMPT = `You are a semantic web automation assistant embedded in a Chrome extension side panel. The user is navigating a web application and describing what they want to automate. You can see the current page's DOM elements.
+
+Your job is to:
+1. Understand what the user wants to capture or automate
+2. Look at the DOM elements provided and identify the right selectors
+3. Build semantic definitions (pages, tools, workflows) incrementally
+4. Ask clarifying questions when needed
+5. When you have enough info, generate YAML definitions
+
+## Naming Rules
+- ALL identifiers must use snake_case: ^[a-z0-9_]+$
+- NEVER use kebab-case (no hyphens)
+
+## When generating definitions, output them in a JSON block:
+\`\`\`definitions
+{
+  "pages": [...],
+  "tools": [...],
+  "workflows": [...]
+}
+\`\`\`
+
+## Selector Strategy Priority
+Use selectors from the actual DOM elements provided:
+1. aria: { strategy: "aria", role: "tab", name: "Details", confidence: 0.95 }
+2. css with ID: { strategy: "css", selector: "#elementId", confidence: 0.90 }
+3. text: { strategy: "text", text: "Button Text", exact: true, confidence: 0.85 }
+4. css class: { strategy: "css", selector: ".specific-class", confidence: 0.80 }
+
+Always include 2+ selector strategies per field as fallbacks.
+
+## Response Style
+- Be concise and conversational
+- When you see DOM elements matching what the user describes, confirm what you found
+- Suggest what to capture next based on context
+- When you generate definitions, also explain what was generated in plain language`;
+
+// Store conversation context per session
+const guideSessions = new Map<string, Array<{ role: string; content: string }>>();
+
+async function handleGuideMessage(
+  sessionId: string,
+  userMessage: string,
+  _history: Array<{ role: string; content: string }>,
+  pageContext: { url: string; title: string; elements: Array<Record<string, unknown>> },
+  recordedActions?: Array<Record<string, unknown>>,
+): Promise<{ reply: string; definitions?: { pages: unknown[]; tools: unknown[]; workflows: unknown[] } }> {
+
+  // Build conversation history
+  if (!guideSessions.has(sessionId)) {
+    guideSessions.set(sessionId, []);
+  }
+  const conversation = guideSessions.get(sessionId)!;
+
+  // Add page context to user message
+  const elementSummary = (pageContext.elements || []).map((el, i) => {
+    const parts = [`${i + 1}. <${el.tag}>`];
+    if (el.role) parts.push(`role="${el.role}"`);
+    if (el.ariaLabel) parts.push(`aria-label="${el.ariaLabel}"`);
+    if (el.text) parts.push(`"${(el.text as string).substring(0, 50)}"`);
+    if (el.id) parts.push(`id="${el.id}"`);
+    if (el.type) parts.push(`type="${el.type}"`);
+    if (el.href) parts.push(`href="${(el.href as string).substring(0, 60)}"`);
+    return parts.join(' ');
+  }).join('\n');
+
+  // Summarize recorded actions if present
+  let actionsSummary = '';
+  if (recordedActions && recordedActions.length > 0) {
+    const actionLines = recordedActions.map((a, i) => {
+      const el = a.element as Record<string, unknown> | undefined;
+      const meta = a.metadata as Record<string, unknown> | undefined;
+      const parts = [`  ${i + 1}. [${String(a.type).toUpperCase()}]`];
+      if (el) {
+        const label = el.nearbyLabel || el.ariaLabel || (el.text as string)?.substring(0, 40) || el.tag;
+        parts.push(`"${label}"`);
+        if (el.ariaRole) parts.push(`(role=${el.ariaRole})`);
+        const selectors = el.selectors as Record<string, unknown> | undefined;
+        if (selectors?.aria) {
+          const aria = selectors.aria as { role: string; name: string };
+          parts.push(`[aria: role=${aria.role}, name="${aria.name}"]`);
+        }
+        if (selectors?.css) parts.push(`[css: ${selectors.css}]`);
+      }
+      if (meta?.inputValue) parts.push(`input="${(meta.inputValue as string).substring(0, 40)}"`);
+      if (meta?.toUrl) parts.push(`-> ${(meta.toUrl as string).substring(0, 80)}`);
+      return parts.join(' ');
+    }).join('\n');
+    actionsSummary = `\n[Recorded Actions (${recordedActions.length} recent):\n${actionLines}]`;
+  }
+
+  const contextMessage = `[Current Page: ${pageContext.url}]
+[Title: ${pageContext.title}]
+[DOM Elements (${pageContext.elements?.length || 0}):
+${elementSummary}]${actionsSummary}
+
+User: ${userMessage}`;
+
+  conversation.push({ role: 'user', content: contextMessage });
+
+  // Call Bedrock
+  console.log(`  Sending to Bedrock (${conversation.length} messages)...`);
+
+  const body = JSON.stringify({
+    anthropic_version: 'bedrock-2023-05-31',
+    max_tokens: 4096,
+    system: GUIDE_SYSTEM_PROMPT,
+    messages: conversation.map(m => ({ role: m.role, content: m.content })),
+  });
+
+  const command = new InvokeModelCommand({
+    modelId: MODEL_ID,
+    body: new TextEncoder().encode(body),
+    contentType: 'application/json',
+    accept: 'application/json',
+  });
+
+  const response = await client.send(command);
+  const responseBody = JSON.parse(new TextDecoder().decode(response.body));
+  const reply = responseBody.content?.[0]?.text || 'No response from model.';
+
+  // Store assistant reply in conversation
+  conversation.push({ role: 'assistant', content: reply });
+
+  // Extract definitions if present
+  let definitions: { pages: unknown[]; tools: unknown[]; workflows: unknown[] } | undefined;
+  const defMatch = reply.match(/```definitions\s*\n([\s\S]*?)```/);
+  if (defMatch) {
+    try {
+      const parsed = JSON.parse(defMatch[1]);
+      definitions = {
+        pages: parsed.pages || [],
+        tools: parsed.tools || [],
+        workflows: parsed.workflows || [],
+      };
+
+      // Auto-save definitions
+      const appId = 'revance_oce_fulldev'; // Default; could be derived from URL
+      try {
+          const saveResult = saveDefinitions(parsed, appId, (parsed.tools as Array<Record<string, unknown>> | undefined)?.[0]?.name as string | undefined);
+          console.log(`  Saved ${saveResult.saved.length} YAML files to ${saveResult.relativeDir}/`);
+        } catch (saveErr) {
+          console.error('  Warning: Failed to save YAML files:', saveErr);
+        }
+    } catch {
+      // Definitions block wasn't valid JSON — that's fine
+    }
+  }
+
+  // Clean reply — remove the definitions block from the displayed message
+  const cleanReply = reply.replace(/```definitions\s*\n[\s\S]*?```/g, '').trim();
+
+  console.log(`  Assistant: "${cleanReply.substring(0, 80)}..."`);
+  if (definitions) {
+    console.log(`  Generated: ${definitions.pages.length} pages, ${definitions.tools.length} tools, ${definitions.workflows.length} workflows`);
+  }
+
+  return { reply: cleanReply, definitions };
+}
+
+// ─── HTTP Server ─────────────────────────────────────────
+
 const server = http.createServer(async (req, res) => {
   // CORS
   res.setHeader('Access-Control-Allow-Origin', '*');
@@ -165,12 +551,217 @@ const server = http.createServer(async (req, res) => {
       try {
         const session = JSON.parse(body);
         console.log(`\nAnalyzing session: ${session.actions?.length || 0} actions, ${session.pages?.length || 0} pages`);
-        const result = await analyzeSession(session);
+        const result = await analyzeSession(session) as Record<string, unknown>;
+
+        // Auto-save YAML files
+        const appId = ((result.app as Record<string, unknown>)?.id as string) || 'captured_app';
+        const appDirName = appId.replace(/[^a-z0-9_]/g, '_');
+        try {
+          const saveResult = saveDefinitions(
+            result,
+            appDirName,
+            (result.tools as Array<Record<string, unknown>> | undefined)?.[0]?.name as string | undefined,
+          );
+          console.log(`Saved ${saveResult.saved.length} YAML files to ${saveResult.relativeDir}/`);
+          saveResult.saved.forEach(f => console.log(`  → ${path.relative(process.cwd(), f)}`));
+          (result as Record<string, unknown>).savedTo = `${saveResult.relativeDir}/`;
+          (result as Record<string, unknown>).savedFiles = saveResult.saved.map(f => path.relative(process.cwd(), f));
+        } catch (saveErr) {
+          console.error('Warning: Failed to save YAML files:', saveErr);
+        }
+
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify(result));
         console.log('Analysis complete.');
       } catch (err) {
         console.error('Analysis error:', err);
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: String(err) }));
+      }
+    });
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/guide') {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', async () => {
+      try {
+        const { sessionId, message, history, pageContext, recordedActions } = JSON.parse(body);
+        console.log(`\n[Guide ${sessionId}] User: "${message.substring(0, 80)}"`);
+        console.log(`  Page: ${pageContext?.url || 'unknown'} (${pageContext?.elements?.length || 0} elements)`);
+        if (recordedActions?.length) console.log(`  Recorded actions: ${recordedActions.length}`);
+
+        const result = await handleGuideMessage(sessionId, message, history || [], pageContext, recordedActions);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(result));
+      } catch (err) {
+        console.error('Guide error:', err);
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: String(err) }));
+      }
+    });
+    return;
+  }
+
+  // ─── /guide-build: AI naming only (no selectors) ──────
+  if (req.method === 'POST' && req.url === '/guide-build') {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', async () => {
+      try {
+        const { pages, actionLabels, capturedFieldLabels } = JSON.parse(body);
+        console.log(`\n[Guide-Build] ${actionLabels?.length || 0} actions, ${pages?.length || 0} pages`);
+
+        const prompt = `You are naming a web automation tool. Given the following info, return a JSON object with tool metadata.
+
+Pages visited: ${JSON.stringify(pages)}
+Actions performed: ${JSON.stringify(actionLabels)}
+Field labels found on pages: ${JSON.stringify(capturedFieldLabels)}
+
+Return ONLY valid JSON (no markdown, no explanation):
+{
+  "name": "snake_case_tool_name",
+  "description": "One sentence describing what the tool does",
+  "inputSchema": {
+    "type": "object",
+    "properties": { "param_name": { "type": "string", "description": "..." } },
+    "required": ["param_name"]
+  },
+  "templateVariables": { "literal_id_from_url": "param_name" }
+}
+
+Rules:
+- name must be snake_case
+- Look at the URLs to identify Salesforce object IDs (15-18 char alphanumeric) and map them to parameter names
+- description should explain the user's workflow based on the actions
+- templateVariables maps literal ID values in URLs to parameter names`;
+
+        const apiBody = JSON.stringify({
+          anthropic_version: 'bedrock-2023-05-31',
+          max_tokens: 1024,
+          messages: [{ role: 'user', content: prompt }],
+        });
+
+        const command = new InvokeModelCommand({
+          modelId: MODEL_ID,
+          body: new TextEncoder().encode(apiBody),
+          contentType: 'application/json',
+          accept: 'application/json',
+        });
+
+        const response = await client.send(command);
+        const responseBody = JSON.parse(new TextDecoder().decode(response.body));
+        let text = responseBody.content?.[0]?.text || '';
+
+        // Parse JSON
+        let cleaned = text.trim();
+        if (cleaned.startsWith('```')) {
+          cleaned = cleaned.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
+        }
+
+        const metadata = JSON.parse(cleaned);
+        console.log(`  Tool name: ${metadata.name}`);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(metadata));
+      } catch (err) {
+        console.error('Guide-build error:', err);
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: String(err) }));
+      }
+    });
+    return;
+  }
+
+  // ─── /save-definitions: Save YAML from builder ────────
+  if (req.method === 'POST' && req.url === '/save-definitions') {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      try {
+        const {
+          appId,
+          app: appDef,
+          pages: pageYamls,
+          tools: toolYamls,
+          captureLabel,
+          debug,
+        } = JSON.parse(body) as {
+          appId: string;
+          app?: Record<string, unknown>;
+          pages: string[];
+          tools: string[];
+          captureLabel?: string;
+          debug?: Record<string, unknown>;
+        };
+        const { outDir: appDir, relativeDir } = resolveOutputDirectory(appId, captureLabel);
+        fs.mkdirSync(path.join(appDir, 'pages'), { recursive: true });
+        fs.mkdirSync(path.join(appDir, 'tools'), { recursive: true });
+
+        const saved: string[] = [];
+        const debugSaved: string[] = [];
+
+        if (appDef) {
+          const appYaml = toYaml({ app: appDef });
+          const appPath = path.join(appDir, 'app.yaml');
+          fs.writeFileSync(appPath, appYaml + '\n');
+          saved.push(appPath);
+        }
+
+        (pageYamls as string[]).forEach((yaml: string, i: number) => {
+          // Extract page id from yaml
+          const idMatch = yaml.match(/id:\s*(\S+)/);
+          const filename = idMatch ? `${idMatch[1]}.yaml` : `page_${i}.yaml`;
+          const filePath = path.join(appDir, 'pages', filename);
+          fs.writeFileSync(filePath, yaml);
+          saved.push(filePath);
+        });
+
+        (toolYamls as string[]).forEach((yaml: string, i: number) => {
+          const nameMatch = yaml.match(/name:\s*(\S+)/);
+          const filename = nameMatch ? `${nameMatch[1]}.yaml` : `tool_${i}.yaml`;
+          const filePath = path.join(appDir, 'tools', filename);
+          fs.writeFileSync(filePath, yaml);
+          saved.push(filePath);
+        });
+
+        if (debug) {
+          const debugDir = path.join(appDir, 'debug');
+          fs.mkdirSync(debugDir, { recursive: true });
+
+          const debugBundlePath = path.join(debugDir, 'guide-session.json');
+          fs.writeFileSync(debugBundlePath, `${JSON.stringify(debug, null, 2)}\n`);
+          debugSaved.push(debugBundlePath);
+
+          const actions = Array.isArray(debug.actions) ? debug.actions : [];
+          const actionsPath = path.join(debugDir, 'recorded-actions.json');
+          fs.writeFileSync(actionsPath, `${JSON.stringify(actions, null, 2)}\n`);
+          debugSaved.push(actionsPath);
+
+          const pageSnapshots = debug.pageSnapshots && typeof debug.pageSnapshots === 'object'
+            ? debug.pageSnapshots
+            : {};
+          const snapshotsPath = path.join(debugDir, 'page-snapshots.json');
+          fs.writeFileSync(snapshotsPath, `${JSON.stringify(pageSnapshots, null, 2)}\n`);
+          debugSaved.push(snapshotsPath);
+        }
+
+        console.log(`\n[Save] Saved ${saved.length} files to ${relativeDir}/`);
+        saved.forEach(f => console.log(`  -> ${path.relative(process.cwd(), f)}`));
+        if (debugSaved.length > 0) {
+          console.log(`[Save] Saved ${debugSaved.length} debug files to ${relativeDir}/debug/`);
+          debugSaved.forEach(f => console.log(`  -> ${path.relative(process.cwd(), f)}`));
+        }
+
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          ok: true,
+          saved,
+          debugSaved,
+          savedTo: `${relativeDir}/`,
+        }));
+      } catch (err) {
+        console.error('Save error:', err);
         res.writeHead(500, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ error: String(err) }));
       }
@@ -186,4 +777,12 @@ server.listen(PORT, () => {
   console.log(`Walk & Capture analysis server running on http://localhost:${PORT}`);
   console.log(`Model: ${MODEL_ID} (region: ${REGION})`);
   console.log('Waiting for sessions from Chrome extension...\n');
+});
+
+process.on('SIGINT', () => {
+  console.log('\nShutting down...');
+  server.close(() => process.exit(0));
+});
+process.on('SIGTERM', () => {
+  server.close(() => process.exit(0));
 });


### PR DESCRIPTION
## Summary

Improves Guide capture reliability for dynamic same-page overlays and quick-filter workflows in the extension.

## What changed

- adds a deterministic Guide mode builder and same-page capture flow for recorded sessions
- improves recorder handling for combobox/listbox-style selections and dedupes duplicate input/change emissions
- saves Guide debug artifacts through the analysis server for easier diagnosis
- keeps timestamped same-URL snapshots and resolves each action against the closest snapshot in time
- prefers semantic quick-filter flows over nearby sort/menu noise in generated tools

## Verification

- `source ~/.zshrc && npx vitest run packages/extension/src/content-script/__tests__/recorder.test.ts`
- `source ~/.zshrc && npx vitest run packages/extension/src/panel/builders/__tests__/yaml-builder.test.ts`
- `source ~/.zshrc && npm run build --workspace @webmcp-bridge/extension`

Closes #71
